### PR TITLE
Clarifies validator key generation script location.

### DIFF
--- a/docs/hayek-validator-kit/ansible-control.md
+++ b/docs/hayek-validator-kit/ansible-control.md
@@ -16,7 +16,7 @@ We have pre-provisioned a sets of keys for the `Canopy` validator that will be r
 
 ### Creating Validator Key Sets
 
-Under the Ansible Control node you will find the script:
+Under the Ansible Control node you will find this script:
 
 &#x20;`/hayek-validator-kit/validator-keys/_gen-validator-keys.sh`&#x20;
 


### PR DESCRIPTION
Updates the documentation to clarify the location of the validator key generation script on the Ansible control node.