### PR TITLE
Completed and tested the user-creation playbook on a virtual server:

### DIFF
--- a/ansible/playbooks/pb_setup_server_users.yml
+++ b/ansible/playbooks/pb_setup_server_users.yml
@@ -7,9 +7,34 @@
 #
 # ansible-playbook -i hosts.yml playbooks/pb_setup_server_users.yml
 
-- name: Setup users for a new metal box
+- name: Setup server users
   hosts: new_metal_box
   user: root
+  become: true
+  pre_tasks:
+    # Gather system facts to get server information
+    - name: Gather facts
+      ansible.builtin.setup:
+
+    # Show server IP and request explicit confirmation
+    - name: Show server IP and request confirmation
+      ansible.builtin.pause:
+        prompt: |
+          IMPORTANT: You are about to run this playbook on the server with IP: {{ ansible_default_ipv4.address }}
+
+          To continue, please type exactly this IP: {{ ansible_default_ipv4.address }}
+
+          If you are not sure, press Ctrl+C to cancel.
+
+          Type IP here
+      register: ip_confirmation
+
+    # Validate that the user typed the correct IP
+    - name: Validate IP input
+      ansible.builtin.fail:
+        msg: "Incorrect IP. Please run the playbook again and type the correct IP."
+      when: ip_confirmation.user_input != ansible_default_ipv4.address
+
   roles:
-    - role: iam_manager
+    - iam_manager
 

--- a/ansible/roles/iam_manager/tasks/backup_vault.yml
+++ b/ansible/roles/iam_manager/tasks/backup_vault.yml
@@ -1,0 +1,44 @@
+---
+# Ensure encryptedpsw directory exists
+- name: Ensure encryptedpsw directory exists
+  ansible.builtin.file:
+    path: "{{ encrypted_password_dir }}"
+    state: directory
+    mode: '0700'
+  delegate_to: localhost
+  run_once: true
+
+# Get current date
+- name: Get current date
+  ansible.builtin.command: date +%Y-%m-%d
+  register: current_date
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+
+# Copy the current vault to encryptedpsw with the date
+- name: Copy vault to encryptedpsw with date
+  ansible.builtin.copy:
+    src: "{{ generated_pass_file }}"
+    dest: "{{ encrypted_password_dir }}/users_{{ current_date.stdout }}.yml"
+    mode: '0600'
+    remote_src: true
+  register: copy_result
+  delegate_to: localhost
+  run_once: true
+
+# Create the output for the vault
+- name: Set fact with the final destination path
+  ansible.builtin.set_fact:
+    vault_path: "{{ encrypted_password_dir }}/users_{{ current_date.stdout }}.yml"
+  delegate_to: localhost
+  run_once: true
+
+# Print Vault Location
+# Shows the command to view the encrypted passwords
+# This helps users locate and access the backup file
+- name: To view encrypted password copy the following
+  ansible.builtin.debug:
+    msg: ansible-vault view "{{ vault_path }}"
+  delegate_to: localhost
+  run_once: true

--- a/ansible/roles/iam_manager/tasks/cleanup.yml
+++ b/ansible/roles/iam_manager/tasks/cleanup.yml
@@ -1,2 +1,14 @@
 ---
-# Perform cleanup here
+# Delete the vault file - this is to avoid issues.
+
+- name: Delete temporal vault file if it exists
+  ansible.builtin.file:
+    path: "{{ generated_pass_file }}"
+    state: absent
+  delegate_to: localhost
+
+- name: Delete temporal vault file if it exists
+  ansible.builtin.file:
+    path: "{{ generated_pass_file }}.bak"
+    state: absent
+  delegate_to: localhost

--- a/ansible/roles/iam_manager/tasks/create_passwords.yml
+++ b/ansible/roles/iam_manager/tasks/create_passwords.yml
@@ -1,0 +1,112 @@
+---
+# Initialize Vault File
+# Creates an empty vault file with secure permissions (0600)
+# This ensures the vault file exists before any operations
+- name: Create empty vault file
+  ansible.builtin.copy:
+    dest: "{{ generated_pass_file }}"
+    content: ""
+    mode: '0600'
+  delegate_to: localhost
+  run_once: true
+
+# Read User Data
+# Reads the CSV file containing user information
+# Uses the 'user' column as the key for each entry
+- name: Read users from CSV
+  ansible.builtin.read_csv:
+    path: "{{ users_file }}"
+    key: user
+  register: users_csv
+  delegate_to: localhost
+  run_once: true
+
+# Debug Output
+# Displays the contents of the CSV file for verification
+# Helps in troubleshooting if there are issues with the CSV data
+- name: Debug CSV content
+  ansible.builtin.debug:
+    var: users_csv
+  delegate_to: localhost
+  run_once: true
+
+# Generate Passwords
+# Creates random passwords for each user with:
+# - 16 characters length
+# - Includes letters, numbers, and special characters (!@*-)
+# - Stores passwords in a dictionary with usernames as keys
+- name: Generate random passwords for users
+  ansible.builtin.set_fact:
+    user_passwords: "{{ user_passwords | default({}) | combine({item.key: lookup('password', '/dev/null length=16 chars=ascii_letters,digits,!@*-')}) }}"
+  loop: "{{ users_csv.dict | dict2items }}"
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+  register: password_result
+  ignore_errors: true
+
+# Debug Password Generation
+# Shows password generation results if there were any errors
+# Only runs if the previous task failed
+- name: Debug password generation result
+  ansible.builtin.debug:
+    var: password_result
+  delegate_to: localhost
+  run_once: true
+  when: password_result is failed
+
+# Create Vault Content
+# Generates the YAML content for the vault file
+# Creates a temporary file with user passwords in YAML format
+- name: Create temporary vault content
+  ansible.builtin.copy:
+    content: |
+      {% for user, password in user_passwords.items() %}
+      {{ user }}_password: "{{ password }}"
+      {% endfor %}
+    dest: "/tmp/new_vault.yml"
+    mode: '0600'
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+
+# Encrypt Vault
+# Encrypts the temporary vault file using ansible-vault
+# Ensures passwords are stored securely
+- name: Encrypt new vault
+  ansible.builtin.command: ansible-vault encrypt /tmp/new_vault.yml
+  delegate_to: localhost
+  run_once: true
+
+# Backup Current Vault
+# Creates a backup of the existing vault file
+# Adds .bak extension to the original file
+- name: Backup existing vault
+  ansible.builtin.copy:
+    src: "{{ generated_pass_file }}"
+    dest: "{{ generated_pass_file }}.bak"
+    mode: '0600'
+  delegate_to: localhost
+  run_once: true
+
+# Update Vault
+# Replaces the current vault with the new encrypted version
+# Maintains secure permissions (0600)
+- name: Replace vault with new one
+  ansible.builtin.copy:
+    src: "/tmp/new_vault.yml"
+    dest: "{{ generated_pass_file }}"
+    mode: '0600'
+    remote_src: true
+  delegate_to: localhost
+  run_once: true
+
+# Cleanup
+# Removes the temporary vault file
+# Ensures no sensitive data remains in temporary storage
+- name: Remove temporary vault file
+  ansible.builtin.file:
+    path: "/tmp/new_vault.yml"
+    state: absent
+  delegate_to: localhost
+  run_once: true

--- a/ansible/roles/iam_manager/tasks/create_passwords.yml
+++ b/ansible/roles/iam_manager/tasks/create_passwords.yml
@@ -20,6 +20,7 @@
   register: users_csv
   delegate_to: localhost
   run_once: true
+  no_log: true
 
 # Debug Output
 # Displays the contents of the CSV file for verification
@@ -29,6 +30,7 @@
     var: users_csv
   delegate_to: localhost
   run_once: true
+  no_log: true
 
 # Generate Passwords
 # Creates random passwords for each user with:
@@ -53,11 +55,18 @@
     var: password_result
   delegate_to: localhost
   run_once: true
+  no_log: true
   when: password_result is failed
 
 # Create Vault Content
 # Generates the YAML content for the vault file
 # Creates a temporary file with user passwords in YAML format
+- name: Get current date
+  ansible.builtin.command: date +%Y-%m-%d
+  register: current_date
+  delegate_to: localhost
+  run_once: true
+
 - name: Create temporary vault content
   ansible.builtin.copy:
     content: |
@@ -73,10 +82,17 @@
 # Encrypt Vault
 # Encrypts the temporary vault file using ansible-vault
 # Ensures passwords are stored securely
+- name: Inform about vault encryption
+  ansible.builtin.debug:
+    msg: |
+      Please enter a password to encrypt the vault file {{ encrypted_password_dir }}/users_{{ current_date.stdout }}.yml
+      IMPORTANT: Save this password! You will need it later to view all the generated user credentials.
+
 - name: Encrypt new vault
   ansible.builtin.command: ansible-vault encrypt /tmp/new_vault.yml
   delegate_to: localhost
   run_once: true
+  no_log: true
 
 # Backup Current Vault
 # Creates a backup of the existing vault file
@@ -88,6 +104,7 @@
     mode: '0600'
   delegate_to: localhost
   run_once: true
+  no_log: true
 
 # Update Vault
 # Replaces the current vault with the new encrypted version
@@ -100,6 +117,7 @@
     remote_src: true
   delegate_to: localhost
   run_once: true
+  no_log: true
 
 # Cleanup
 # Removes the temporary vault file
@@ -110,3 +128,4 @@
     state: absent
   delegate_to: localhost
   run_once: true
+  no_log: true

--- a/ansible/roles/iam_manager/tasks/create_users.yml
+++ b/ansible/roles/iam_manager/tasks/create_users.yml
@@ -7,11 +7,13 @@
     state: present
   loop: "{{ users_csv.dict | dict2items }}"
   when: item.value.create_user | default(true)
+  no_log: true
 
 # Get unique groups from CSV
 - name: Get unique groups
   ansible.builtin.set_fact:
     unique_groups: "{{ (users_csv.dict.values() | map(attribute='group_a') | list + users_csv.dict.values() | map(attribute='group_b') | list) | select('string') | unique | list }}"
+  no_log: true
 
 # Create groups from CSV
 - name: Create groups from CSV
@@ -20,6 +22,7 @@
     state: present
   loop: "{{ unique_groups }}"
   when: item != ""
+  no_log: true
 
 # Add users to groups
 - name: Add users to groups
@@ -29,14 +32,17 @@
     append: true
   loop: "{{ users_csv.dict | dict2items }}"
   when: item.value.create_user | default(true) and ((item.value.group_a | default('') != '') or (item.value.group_b | default('') != ''))
+  no_log: true
 
 # Set passwords for users
 - name: Set passwords for users
   ansible.builtin.user:
     name: "{{ item.key }}"
     password: "{{ user_passwords[item.key] | password_hash('sha512') }}"
+    update_password: always
   loop: "{{ users_csv.dict | dict2items }}"
   when: item.value.create_user | default(true)
+  no_log: true
 
 # Configure password expiration for users
 - name: Configure password expiration for users
@@ -44,6 +50,7 @@
   loop: "{{ users_csv.dict | dict2items }}"
   when: item.value.create_user | default(true)
   changed_when: false
+  no_log: true
 
 # Create ssh directories for users
 - name: Ensure .ssh directories exist
@@ -55,6 +62,7 @@
     group: "{{ item.key }}"
   loop: "{{ users_csv.dict | dict2items }}"
   when: item.value.create_user | default(true)
+  no_log: true
 
 # Add SSH authorized keys
 - name: Add authorized keys
@@ -63,8 +71,10 @@
     key: "{{ item.value.key }}"
   loop: "{{ users_csv.dict | dict2items }}"
   when: item.value.create_user | default(true) and item.value.key is defined and item.value.key != ""
+  no_log: true
 
 # Set ubuntu user password expiration
 - name: Set password expiration for ubuntu user
   ansible.builtin.command: chage -M 1 ubuntu
   changed_when: false
+  no_log: true

--- a/ansible/roles/iam_manager/tasks/create_users.yml
+++ b/ansible/roles/iam_manager/tasks/create_users.yml
@@ -1,0 +1,70 @@
+---
+# Create users from CSV data
+- name: Create users from CSV
+  ansible.builtin.user:
+    name: "{{ item.key }}"
+    shell: /bin/bash
+    state: present
+  loop: "{{ users_csv.dict | dict2items }}"
+  when: item.value.create_user | default(true)
+
+# Get unique groups from CSV
+- name: Get unique groups
+  ansible.builtin.set_fact:
+    unique_groups: "{{ (users_csv.dict.values() | map(attribute='group_a') | list + users_csv.dict.values() | map(attribute='group_b') | list) | select('string') | unique | list }}"
+
+# Create groups from CSV
+- name: Create groups from CSV
+  ansible.builtin.group:
+    name: "{{ item | lower }}"
+    state: present
+  loop: "{{ unique_groups }}"
+  when: item != ""
+
+# Add users to groups
+- name: Add users to groups
+  ansible.builtin.user:
+    name: "{{ item.key }}"
+    groups: "{{ (item.value.group_a | default('') | lower + ',' + item.value.group_b | default('') | lower) | regex_replace('^,|,$', '') | regex_replace(',,', ',') | regex_replace('^$', '') }}"
+    append: true
+  loop: "{{ users_csv.dict | dict2items }}"
+  when: item.value.create_user | default(true) and ((item.value.group_a | default('') != '') or (item.value.group_b | default('') != ''))
+
+# Set passwords for users
+- name: Set passwords for users
+  ansible.builtin.user:
+    name: "{{ item.key }}"
+    password: "{{ user_passwords[item.key] | password_hash('sha512') }}"
+  loop: "{{ users_csv.dict | dict2items }}"
+  when: item.value.create_user | default(true)
+
+# Configure password expiration for users
+- name: Configure password expiration for users
+  ansible.builtin.command: "chage -d 0 {{ item.key }}"
+  loop: "{{ users_csv.dict | dict2items }}"
+  when: item.value.create_user | default(true)
+  changed_when: false
+
+# Create ssh directories for users
+- name: Ensure .ssh directories exist
+  ansible.builtin.file:
+    path: "/home/{{ item.key }}/.ssh"
+    state: directory
+    mode: '0700'
+    owner: "{{ item.key }}"
+    group: "{{ item.key }}"
+  loop: "{{ users_csv.dict | dict2items }}"
+  when: item.value.create_user | default(true)
+
+# Add SSH authorized keys
+- name: Add authorized keys
+  ansible.posix.authorized_key:
+    user: "{{ item.key }}"
+    key: "{{ item.value.key }}"
+  loop: "{{ users_csv.dict | dict2items }}"
+  when: item.value.create_user | default(true) and item.value.key is defined and item.value.key != ""
+
+# Set ubuntu user password expiration
+- name: Set password expiration for ubuntu user
+  ansible.builtin.command: chage -M 1 ubuntu
+  changed_when: false

--- a/ansible/roles/iam_manager/tasks/disable_ubuntu.yml
+++ b/ansible/roles/iam_manager/tasks/disable_ubuntu.yml
@@ -31,6 +31,7 @@
     state: present
   register: ssh_config_changed
   no_log: true
+  ignore_errors: true
 
 - name: Restart SSH service
   ansible.builtin.service:
@@ -38,3 +39,4 @@
     state: restarted
   when: ssh_config_changed.changed
   no_log: true
+  ignore_errors: true

--- a/ansible/roles/iam_manager/tasks/disable_ubuntu.yml
+++ b/ansible/roles/iam_manager/tasks/disable_ubuntu.yml
@@ -1,0 +1,40 @@
+---
+# Pause to let user read the warning
+- name: Notify about upcoming ubuntu user disablement
+  ansible.builtin.debug:
+    msg: |
+      IMPORTANT WARNING: The ubuntu user will now be disabled.
+      After this task completes, you will LOSE CONNECTION to this server.
+      Please ensure you can connect with one of the newly created users:
+      {% for user in users_csv.dict.keys() %}
+      - {{ user }}
+      {% endfor %}
+
+- name: Pause for warning
+  ansible.builtin.pause:
+    prompt: "Press Enter to continue and disable ubuntu user (you will lose connection!), or Ctrl+C to abort"
+
+# Disable ubuntu user
+- name: Disable ubuntu user
+  ansible.builtin.user:
+    name: ubuntu
+    state: present
+    password_lock: true
+    shell: /usr/sbin/nologin
+  no_log: true
+
+- name: Block SSH login for ubuntu user
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^DenyUsers .*ubuntu.*'
+    line: 'DenyUsers ubuntu'
+    state: present
+  register: ssh_config_changed
+  no_log: true
+
+- name: Restart SSH service
+  ansible.builtin.service:
+    name: sshd
+    state: restarted
+  when: ssh_config_changed.changed
+  no_log: true

--- a/ansible/roles/iam_manager/tasks/encrypt_passwords.yml
+++ b/ansible/roles/iam_manager/tasks/encrypt_passwords.yml
@@ -14,6 +14,13 @@
   delegate_to: localhost
   run_once: true
 
+# Decrypts the vault file to get the generated passwords
+- name: Inform about vault password
+  ansible.builtin.debug:
+    msg: |
+      Please enter the password for the generated passwords vault file ({{ generated_pass_file }})
+      This password is needed to access the user passwords that were previously generated.
+
 # Read passwords from vault file
 # Decrypts the vault file to get the generated passwords
 - name: Read passwords from vault

--- a/ansible/roles/iam_manager/tasks/encrypt_passwords.yml
+++ b/ansible/roles/iam_manager/tasks/encrypt_passwords.yml
@@ -1,0 +1,58 @@
+---
+# Update apt cache
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: yes
+  delegate_to: localhost
+  run_once: true
+
+# Ensure age is installed
+- name: Ensure age is installed
+  ansible.builtin.package:
+    name: age
+    state: present
+  delegate_to: localhost
+  run_once: true
+
+# Read passwords from vault file
+# Decrypts the vault file to get the generated passwords
+- name: Read passwords from vault
+  ansible.builtin.command: ansible-vault view "{{ generated_pass_file }}"
+  register: vault_content
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+
+# Parse vault content to get passwords
+# Extracts passwords from the vault content using the CSV usernames
+- name: Parse vault content
+  ansible.builtin.set_fact:
+    user_passwords: "{{ user_passwords | default({}) | combine({item: vault_content.stdout | regex_search(item + '_password: \"(.*?)\"', '\\1') | first}) }}"
+  loop: "{{ users_csv.dict.keys() | list }}"
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+
+# Create encrypted password files
+# Encrypts each user's password using age
+- name: Create encrypted password files
+  ansible.builtin.shell: >
+    echo "{{ user_passwords[item] }}" | age -r "{{ users_csv.dict[item].key }}" > /tmp/{{ item }}_password.age
+  loop: "{{ users_csv.dict.keys() | list }}"
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+  register: encryption_result
+
+# Read encrypted passwords
+# Reads the encrypted password files and stores them in a variable
+# This allows for secure transmission of passwords to the remote server
+- name: Read encrypted passwords
+  ansible.builtin.slurp:
+    src: "/tmp/{{ item }}_password.age"
+  register: encrypted_passwords
+  loop: "{{ users_csv.dict.keys() | list }}"
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+

--- a/ansible/roles/iam_manager/tasks/main.yml
+++ b/ansible/roles/iam_manager/tasks/main.yml
@@ -27,6 +27,10 @@
 - name: Cleanup
   import_tasks: cleanup.yml
 
-
+# Send credentials via email to users marked for email notification
 - name: Send credentials via email
   import_tasks: send_emails.yml
+
+# Disable ubuntu user and block SSH access
+- name: Disable ubuntu user
+  import_tasks: disable_ubuntu.yml

--- a/ansible/roles/iam_manager/tasks/main.yml
+++ b/ansible/roles/iam_manager/tasks/main.yml
@@ -1,6 +1,32 @@
 ---
+# Verify that all required variables and inputs are present before proceeding
 - name: Precheck role imputs
   import_tasks: precheck.yml
 
+# Initial cleanup of any temporary files or previous failed states
 - name: Cleanup
   import_tasks: cleanup.yml
+
+# Generate random passwords for users and store them in the vault file
+- name: Create passwords
+  import_tasks: create_passwords.yml
+
+# Encrypt passwords using age for each user
+- name: Encrypt passwords with age
+  import_tasks: encrypt_passwords.yml
+
+# Create system users, assign groups, and configure SSH access
+- name: Create users
+  import_tasks: create_users.yml
+
+# Create a dated backup of the vault file with passwords
+- name: Backup vault file
+  import_tasks: backup_vault.yml
+
+# Final cleanup of any temporary files created during execution
+- name: Cleanup
+  import_tasks: cleanup.yml
+
+
+- name: Send credentials via email
+  import_tasks: send_emails.yml

--- a/ansible/roles/iam_manager/tasks/precheck.yml
+++ b/ansible/roles/iam_manager/tasks/precheck.yml
@@ -1,5 +1,6 @@
 ---
-# Read users from CSV file
+# Precheck 1: Read and validate CSV file
+# This task reads the CSV file containing user information and validates its structure
 - name: Read users from CSV
   ansible.builtin.read_csv:
     path: "{{ users_file }}"
@@ -8,12 +9,17 @@
   delegate_to: localhost
   run_once: true
 
+# Precheck 2: Debug output
+# Displays the contents of the CSV file for verification purposes
 - name: Debug CSV content
   ansible.builtin.debug:
     var: users_csv
   delegate_to: localhost
   run_once: true
 
+# Precheck 3: Validate CSV structure
+# Ensures the CSV file has the required fields (user, email, sent_email, key)
+# Fails if the CSV is empty or missing required fields
 - name: Verify CSV data structure
   ansible.builtin.fail:
     msg: "Invalid CSV structure. Required fields: user, email, sent_email, key"
@@ -23,6 +29,26 @@
   delegate_to: localhost
   run_once: true
 
+# Precheck 4: Check for existing users
+# Uses cut command to get a list of existing users from /etc/passwd
+# This is a security check to prevent overwriting existing users
+- name: Get list of existing users
+  ansible.builtin.shell: "cut -d: -f1 /etc/passwd"
+  register: existing_users
+  changed_when: false
+
+# # Precheck 5: Fail if users exist
+# # Compares users from CSV with existing system users
+# # If any users already exist, the playbook will fail for security reasons
+# - name: Check for existing users
+#   ansible.builtin.fail:
+#     msg: "It appears this server has already been installed (existing users: {{ existing_users_list | join(', ') }}). For security reasons, this configuration will not continue."
+#   when: existing_users_list | length > 0
+#   vars:
+#     existing_users_list: "{{ users_csv.dict.keys() | select('in', existing_users.stdout_lines) | list }}"
+
+# Precheck 6: Display inventory directory
+# Shows the inventory directory path for verification
 - name: Display message in console
   ansible.builtin.debug:
     msg: "{{ inventory_dir }}"

--- a/ansible/roles/iam_manager/tasks/precheck.yml
+++ b/ansible/roles/iam_manager/tasks/precheck.yml
@@ -15,6 +15,7 @@
   ansible.builtin.debug:
     var: users_csv
   delegate_to: localhost
+  no_log: true
   run_once: true
 
 # Precheck 3: Validate CSV structure
@@ -37,15 +38,15 @@
   register: existing_users
   changed_when: false
 
-# # Precheck 5: Fail if users exist
-# # Compares users from CSV with existing system users
-# # If any users already exist, the playbook will fail for security reasons
-# - name: Check for existing users
-#   ansible.builtin.fail:
-#     msg: "It appears this server has already been installed (existing users: {{ existing_users_list | join(', ') }}). For security reasons, this configuration will not continue."
-#   when: existing_users_list | length > 0
-#   vars:
-#     existing_users_list: "{{ users_csv.dict.keys() | select('in', existing_users.stdout_lines) | list }}"
+# Precheck 5: Fail if users exist
+# Compares users from CSV with existing system users
+# If any users already exist, the playbook will fail for security reasons
+- name: Check for existing users
+  ansible.builtin.fail:
+    msg: "It appears this server has already been installed (existing users: {{ existing_users_list | join(', ') }}). For security reasons, this configuration will not continue."
+  when: existing_users_list | length > 0
+  vars:
+    existing_users_list: "{{ users_csv.dict.keys() | select('in', existing_users.stdout_lines) | list }}"
 
 # Precheck 6: Display inventory directory
 # Shows the inventory directory path for verification

--- a/ansible/roles/iam_manager/tasks/send_emails.yml
+++ b/ansible/roles/iam_manager/tasks/send_emails.yml
@@ -1,0 +1,96 @@
+---
+# Read vault file for SMTP variables
+- name: Read vault file
+  ansible.builtin.command: ansible-vault view "{{ vault_file }}"
+  register: vault_content
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+
+# Parse email variables
+- name: Parse email variables
+  ansible.builtin.set_fact:
+    smtp_host: "{{ vault_content.stdout | regex_search('smtp_host: (.*)', '\\1') | first }}"
+    smtp_port: "{{ vault_content.stdout | regex_search('smtp_port: (.*)', '\\1') | first }}"
+    smtp_username: "{{ vault_content.stdout | regex_search('smtp_username: \"(.*?)\"', '\\1') | first }}"
+    smtp_password: "{{ vault_content.stdout | regex_search('smtp_password: \"(.*?)\"', '\\1') | first }}"
+    smtp_from: "{{ vault_content.stdout | regex_search('smtp_from: \"(.*?)\"', '\\1') | first }}"
+    smtp_from_name: "{{ vault_content.stdout | regex_search('smtp_from_name: \"(.*?)\"', '\\1') | first }}"
+  delegate_to: localhost
+  run_once: true
+  no_log: true
+
+# Read CSV file
+- name: Read users from CSV
+  ansible.builtin.read_csv:
+    path: "{{ users_file }}"
+    key: user
+  register: users_csv
+  delegate_to: localhost
+  run_once: true
+
+# Send passwords via email
+- name: Send passwords via email
+  community.general.mail:
+    host: "{{ smtp_host | default('smtp.gmail.com') }}"
+    port: "{{ smtp_port | default(587) }}"
+    username: "{{ smtp_username }}"
+    password: "{{ smtp_password }}"
+    to: "{{ item.value.email }}"
+    subject: "Your server access credentials"
+    body: |
+      Hello {{ item.value.user }},
+
+      Your server access credentials have been encrypted with your SSH public key.
+      For decrypt the password, you need to have the private key of the user.
+
+      Server IP: {{ ansible_default_ipv4.address }}
+      Username: {{ item.value.user }}
+
+      The encrypted password file is attached to this email.
+
+      To decrypt your password:
+      1. Install age if not already installed:
+         - On Ubuntu/Debian: apt install age
+         - On macOS: brew install age
+      2. Save the attachment and run:
+         age -d -i ~/.ssh/private_key {{ item.value.user }}_password.age
+
+      Connection command:
+      ssh -p 2522 {{ item.value.user }}@{{ ansible_default_ipv4.address }}
+
+      Please change your password upon first login.
+
+      Best regards,
+      {{ smtp_from_name | default('System Administrator') }}
+    from: "{{ smtp_from | default('system@example.com') }}"
+    secure: starttls
+    attach:
+      - "/tmp/{{ item.value.user }}_password.age"
+  loop: "{{ users_csv.dict | dict2items }}"
+  delegate_to: localhost
+  run_once: true
+  when:
+    - smtp_username is defined
+    - smtp_password is defined
+    - item.value.sent_email | upper == 'TRUE'
+
+# Clean up temporary files
+- name: Clean up encrypted password files
+  ansible.builtin.file:
+    path: "/tmp/{{ item }}_password.age"
+    state: absent
+  loop: "{{ users_csv.dict.keys() | list }}"
+  delegate_to: localhost
+  run_once: true
+
+# Notify before disabling ubuntu user
+- name: Notify about upcoming ubuntu user disablement
+  ansible.builtin.debug:
+    msg: |
+      IMPORTANT WARNING: The ubuntu user will now be disabled.
+      After this task completes, you will LOSE CONNECTION to this server.
+      Please ensure you can connect with one of the newly created users:
+      {% for user in users_csv.dict.keys() %}
+      - {{ user }}
+      {% endfor %}

--- a/ansible/roles/iam_manager/tasks/send_emails.yml
+++ b/ansible/roles/iam_manager/tasks/send_emails.yml
@@ -1,4 +1,11 @@
 ---
+# Show message about vault password
+- name: Inform about vault password
+  ansible.builtin.debug:
+    msg: |
+      Please enter the password for the SMTP vault file ({{ vault_file }})
+      This password is needed to access the email configuration.
+
 # Read vault file for SMTP variables
 - name: Read vault file
   ansible.builtin.command: ansible-vault view "{{ vault_file }}"
@@ -28,6 +35,7 @@
   register: users_csv
   delegate_to: localhost
   run_once: true
+  no_log: true
 
 # Send passwords via email
 - name: Send passwords via email
@@ -38,31 +46,7 @@
     password: "{{ smtp_password }}"
     to: "{{ item.value.email }}"
     subject: "Your server access credentials"
-    body: |
-      Hello {{ item.value.user }},
-
-      Your server access credentials have been encrypted with your SSH public key.
-      For decrypt the password, you need to have the private key of the user.
-
-      Server IP: {{ ansible_default_ipv4.address }}
-      Username: {{ item.value.user }}
-
-      The encrypted password file is attached to this email.
-
-      To decrypt your password:
-      1. Install age if not already installed:
-         - On Ubuntu/Debian: apt install age
-         - On macOS: brew install age
-      2. Save the attachment and run:
-         age -d -i ~/.ssh/private_key {{ item.value.user }}_password.age
-
-      Connection command:
-      ssh -p 2522 {{ item.value.user }}@{{ ansible_default_ipv4.address }}
-
-      Please change your password upon first login.
-
-      Best regards,
-      {{ smtp_from_name | default('System Administrator') }}
+    body: "{{ lookup('template', 'email_credentials.j2') }}"
     from: "{{ smtp_from | default('system@example.com') }}"
     secure: starttls
     attach:
@@ -70,6 +54,7 @@
   loop: "{{ users_csv.dict | dict2items }}"
   delegate_to: localhost
   run_once: true
+  no_log: true
   when:
     - smtp_username is defined
     - smtp_password is defined
@@ -83,14 +68,5 @@
   loop: "{{ users_csv.dict.keys() | list }}"
   delegate_to: localhost
   run_once: true
+  no_log: true
 
-# Notify before disabling ubuntu user
-- name: Notify about upcoming ubuntu user disablement
-  ansible.builtin.debug:
-    msg: |
-      IMPORTANT WARNING: The ubuntu user will now be disabled.
-      After this task completes, you will LOSE CONNECTION to this server.
-      Please ensure you can connect with one of the newly created users:
-      {% for user in users_csv.dict.keys() %}
-      - {{ user }}
-      {% endfor %}

--- a/ansible/roles/iam_manager/templates/email_credentials.j2
+++ b/ansible/roles/iam_manager/templates/email_credentials.j2
@@ -1,0 +1,24 @@
+Hello {{ item.value.user }},
+
+Your server access credentials have been encrypted with your SSH public key.
+For decrypt the password, you need to have the private key of the user.
+
+Server IP: {{ ansible_default_ipv4.address }}
+Username: {{ item.value.user }}
+
+The encrypted password file is attached to this email.
+
+To decrypt your password:
+1. Install age if not already installed:
+   - On Ubuntu/Debian: apt install age
+   - On macOS: brew install age
+2. Save the attachment and run:
+   age -d -i ~/.ssh/private_key {{ item.value.user }}_password.age
+
+Connection command:
+ssh -p 2522 {{ item.value.user }}@{{ ansible_default_ipv4.address }}
+
+Please change your password upon first login.
+
+Best regards,
+{{ smtp_from_name | default('System Administrator') }}

--- a/ansible/roles/iam_manager/vars/main.yml
+++ b/ansible/roles/iam_manager/vars/main.yml
@@ -1,4 +1,12 @@
 ---
-# iam variables
-vault_file: "{{ inventory_dir }}/vault/group_vars/email_vars.yml"
+# CSV file containing user information (username, groups, email, etc.)
 users_file: "~/.new-metal-box-secrets/users.csv"
+
+# Vault file containing email-related variables and configurations
+vault_file: "{{ inventory_dir }}/vault/group_vars/email_vars.yml"
+
+# Vault file where generated passwords will be stored
+generated_pass_file: "{{ inventory_dir }}/vault/group_vars/generated_pass.yml"
+
+# Directory for storing encrypted password backups with timestamps
+encrypted_password_dir: "~/.encryptedpsw"


### PR DESCRIPTION
Removed all hardcoded references to usernames, groups, emails, and SSH keys.

Now, all user details (username, group membership, email, public key) must be provided via a CSV file.

The CSV should be placed in a local folder that is mounted into the Ansible Control Docker container.

Tested end-to-end workflow: CSV import → user creation → key distribution → email notifications.