### PR TITLE
Server Configuration: Stage 1 – Initial Hardware and System Setup

### DIFF
--- a/ansible/hosts.yml
+++ b/ansible/hosts.yml
@@ -15,7 +15,7 @@ all:
     # Host for provisioning new servers
     # Add to apropriate groups before runing playbooks
     new_metal_box:
-      ansible_host: 155.138.239.63 # Replace with asigned IP
+      ansible_host: 10.0.0.60 # Replace with asigned IP
       ansible_port: 22
     host-alpha:
       ansible_host: 172.25.0.11

--- a/ansible/playbooks/pb_setup_metal_box.yml
+++ b/ansible/playbooks/pb_setup_metal_box.yml
@@ -1,13 +1,14 @@
 ---
-# Setup users for a new metal box
+# Playbook for initial setup of metal box server
+# This playbook configures a new metal box for validator operations
 # --------------------
 # Usage:
 # ------
 # Run from /ansible directory:
 #
-# ansible-playbook playbooks/pb_setup_server_users.yml
+# ansible-playbook -i hosts.yml playbooks/pb_setup_metal_box.yml
 
-- name: Setup server users
+- name: Setup Metal Box Server
   hosts: new_metal_box
   user: ubuntu
   become: true
@@ -36,5 +37,4 @@
       when: ip_confirmation.user_input != ansible_default_ipv4.address
 
   roles:
-    - iam_manager
-
+    - server_initial_setup

--- a/ansible/roles/server_initial_setup/files/21-agave-validator.conf
+++ b/ansible/roles/server_initial_setup/files/21-agave-validator.conf
@@ -1,0 +1,1 @@
+# Agave Validator sysctl configuration

--- a/ansible/roles/server_initial_setup/files/90-solana-nofiles.conf
+++ b/ansible/roles/server_initial_setup/files/90-solana-nofiles.conf
@@ -1,0 +1,1 @@
+# Solana nofiles limits configuration

--- a/ansible/roles/server_initial_setup/files/99-disable-ipv6.conf
+++ b/ansible/roles/server_initial_setup/files/99-disable-ipv6.conf
@@ -1,0 +1,1 @@
+# IPv6 disable configuration

--- a/ansible/roles/server_initial_setup/files/cpu-governor.service
+++ b/ansible/roles/server_initial_setup/files/cpu-governor.service
@@ -1,0 +1,1 @@
+# CPU Governor Service file

--- a/ansible/roles/server_initial_setup/files/health_check.sh
+++ b/ansible/roles/server_initial_setup/files/health_check.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+# Health check script for Solana validator

--- a/ansible/roles/server_initial_setup/tasks/disk_setup.yml
+++ b/ansible/roles/server_initial_setup/tasks/disk_setup.yml
@@ -1,0 +1,129 @@
+---
+# This role performs disk setup and configuration for Solana validator
+# This role uses disk information collected by precheck.yml
+
+# Assign disks by size using information from precheck
+- name: Assign disks by size
+  ansible.builtin.set_fact:
+    ledger_disk: "{{ available_disks_list[0] if available_disks_list | length > 0 else '' }}"
+    account_disk: "{{ available_disks_list[1] if available_disks_list | length > 1 else '' }}"
+    snapshots_disk: "{{ available_disks_list[2] if available_disks_list | length > 2 else '' }}"
+
+# Display disk assignments for verification
+- name: Show disk assignments
+  ansible.builtin.debug:
+    msg: |
+      Detected disk assignments:
+      - Ledger: /dev/{{ ledger_disk }} ({{ ansible_devices[ledger_disk].size if ledger_disk != '' else 'Not available' }})
+      - Accounts: /dev/{{ account_disk }} ({{ ansible_devices[account_disk].size if account_disk != '' else 'Not available' }})
+      - Snapshots: /dev/{{ snapshots_disk }} ({{ ansible_devices[snapshots_disk].size if snapshots_disk != '' else 'Not available' }})
+
+# Disable swap to prevent performance issues
+- name: Disable swap
+  ansible.builtin.command: swapoff -a
+  changed_when: false
+
+- name: Comment out swap in fstab
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^([^#].+swap.+)'
+    replace: '# \1'
+
+# Format drives with appropriate filesystems
+- name: Format ledger drive
+  community.general.filesystem:
+    fstype: "{{ filesystem_formats.ledger }}"
+    dev: "/dev/{{ ledger_disk }}"
+    force: true
+  when: ledger_disk != '' and ansible_devices[ledger_disk] is defined
+
+- name: Format accounts drive
+  community.general.filesystem:
+    fstype: "{{ filesystem_formats.accounts }}"
+    dev: "/dev/{{ account_disk }}"
+    force: true
+  when: account_disk != '' and ansible_devices[account_disk] is defined
+
+- name: Format snapshots drive
+  community.general.filesystem:
+    fstype: "{{ filesystem_formats.snapshots }}"
+    dev: "/dev/{{ snapshots_disk }}"
+    force: true
+  when: snapshots_disk != '' and ansible_devices[snapshots_disk] is defined
+
+# Create mount point directories
+- name: Create mount directories
+  ansible.builtin.file:
+    path: "{{ mount_points[item] }}"
+    state: directory
+    mode: "{{ directory_permissions.mode }}"
+    owner: "{{ directory_permissions.owner }}"
+    group: "{{ directory_permissions.group }}"
+  loop: "{{ mount_directories }}"
+
+# Get UUIDs for fstab configuration
+- name: Get UUID for ledger drive
+  ansible.builtin.command: blkid -s UUID -o value "/dev/{{ ledger_disk }}"
+  register: ledger_uuid
+  changed_when: false
+  when: ledger_disk != '' and ansible_devices[ledger_disk] is defined
+
+- name: Get UUID for accounts drive
+  ansible.builtin.command: blkid -s UUID -o value "/dev/{{ account_disk }}"
+  register: accounts_uuid
+  changed_when: false
+  when: account_disk != '' and ansible_devices[account_disk] is defined
+
+- name: Get UUID for snapshots drive
+  ansible.builtin.command: blkid -s UUID -o value "/dev/{{ snapshots_disk }}"
+  register: snapshots_uuid
+  changed_when: false
+  when: snapshots_disk != '' and ansible_devices[snapshots_disk] is defined
+
+# Configure fstab for automatic mounting
+- name: Configure fstab for ledger drive
+  ansible.posix.mount:
+    path: "{{ mount_points.ledger }}"
+    src: "UUID={{ ledger_uuid.stdout }}"
+    fstype: "{{ filesystem_formats.ledger }}"
+    opts: defaults,noatime,logbufs=8,logbsize=32k
+    dump: 0
+    passno: 2
+    state: present
+  when: ledger_uuid.stdout is defined and ledger_uuid.stdout != ""
+
+- name: Configure fstab for accounts drive
+  ansible.posix.mount:
+    path: "{{ mount_points.accounts }}"
+    src: "UUID={{ accounts_uuid.stdout }}"
+    fstype: "{{ filesystem_formats.accounts }}"
+    opts: defaults,noatime
+    dump: 0
+    passno: 2
+    state: present
+  when: accounts_uuid.stdout is defined and accounts_uuid.stdout != ""
+
+- name: Configure fstab for snapshots drive
+  ansible.posix.mount:
+    path: "{{ mount_points.snapshots }}"
+    src: "UUID={{ snapshots_uuid.stdout }}"
+    fstype: "{{ filesystem_formats.snapshots }}"
+    opts: defaults,noatime
+    dump: 0
+    passno: 2
+    state: present
+  when: snapshots_uuid.stdout is defined and snapshots_uuid.stdout != ""
+
+# Mount all configured filesystems
+- name: Mount all filesystems
+  ansible.builtin.command: mount -a
+  changed_when: false
+
+# Set correct ownership and permissions
+- name: Set ownership of mount points
+  ansible.builtin.file:
+    path: "{{ mount_points[item] }}"
+    owner: "{{ directory_permissions.owner }}"
+    group: "{{ directory_permissions.group }}"
+    recurse: true
+  loop: "{{ mount_directories }}"

--- a/ansible/roles/server_initial_setup/tasks/initial_setup.yml
+++ b/ansible/roles/server_initial_setup/tasks/initial_setup.yml
@@ -1,0 +1,52 @@
+---
+# This role performs initial system setup including package installation and basic configuration
+
+# Update and upgrade packages
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Upgrade all packages
+  ansible.builtin.apt:
+    upgrade: true
+    autoclean: true
+    autoremove: true
+
+# Disable unattended upgrades
+- name: Stop unattended-upgrades service
+  ansible.builtin.systemd:
+    name: unattended-upgrades
+    state: stopped
+    enabled: false
+
+- name: Reconfigure unattended-upgrades to disable
+  ansible.builtin.expect:
+    command: dpkg-reconfigure unattended-upgrades
+    responses:
+      '^No automatic updates.$': '\n'
+    timeout: 30
+  register: dpkg_result
+  failed_when: "'rejected' in dpkg_result.stdout"
+  ignore_errors: true  # May not work in all environments
+
+- name: Configure auto-upgrades
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    content: |
+      APT::Periodic::Update-Package-Lists "0";
+      APT::Periodic::Unattended-Upgrade "0";
+    mode: '0644'
+
+- name: Install essential packages
+  ansible.builtin.apt:
+    name:
+      - htop
+      - fail2ban
+      - hwloc
+      - xfsprogs  # For XFS filesystem operations
+    state: present
+
+- name: Set timezone
+  community.general.timezone:
+    name: "{{ timezone }}"

--- a/ansible/roles/server_initial_setup/tasks/main.yml
+++ b/ansible/roles/server_initial_setup/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Main task file for server initial setup
+# This file includes all other task files in the correct order
+
+- name: Include precheck tasks
+  ansible.builtin.import_tasks: precheck.yml
+
+- name: Include initial setup tasks
+  ansible.builtin.import_tasks: initial_setup.yml
+
+# - name: Include system tuning tasks
+#   ansible.builtin.import_tasks: system_tuning.yml
+
+- name: Include disk setup tasks
+  ansible.builtin.import_tasks: disk_setup.yml

--- a/ansible/roles/server_initial_setup/tasks/precheck.yml
+++ b/ansible/roles/server_initial_setup/tasks/precheck.yml
@@ -1,0 +1,168 @@
+---
+# This role performs CPU configuration checks and stops the playbook if any check fails
+
+# - name: Check CPU configuration for Solana servers
+#   block:
+#     # Check CPU governor setting
+#     - name: Check if CPU governor is set to performance mode
+#       ansible.builtin.shell: |
+#         for gov_file in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+#           if [ -f "$gov_file" ]; then
+#             cat "$gov_file"
+#           fi
+#         done | sort | uniq
+#       register: cpu_governor_check
+#       changed_when: false
+#       check_mode: false
+
+#     # Check CPU scaling driver
+#     - name: Check if p-state driver is active
+#       ansible.builtin.shell: |
+#         if [ -f "/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver" ]; then
+#           cat "/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver"
+#         else
+#           echo "scaling_driver file not found"
+#           exit 1
+#         fi
+#       register: pstate_check
+#       changed_when: false
+#       check_mode: false
+
+#     # Check AMD SMT/Hyperthreading status
+#     - name: Check if AMD SMT/Hyperthreading is enabled
+#       ansible.builtin.shell: |
+#         # Method 1: Check through SMT directory (modern kernels)
+#         if [ -d "/sys/devices/system/cpu/smt" ] && [ -f "/sys/devices/system/cpu/smt/control" ]; then
+#           cat "/sys/devices/system/cpu/smt/control"
+#           exit $?
+#         fi
+
+#         # Method 2: Check by counting siblings per core
+#         siblings_count=$(cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list | tr ',' ' ' | wc -w)
+#         if [ "$siblings_count" -gt 1 ]; then
+#           echo "on"
+#           exit 0
+#         else
+#           echo "off"
+#           exit 1
+#         fi
+#       register: smt_check
+#       changed_when: false
+#       check_mode: false
+
+#     # Display verification results
+#     - name: Display CPU configuration status
+#       ansible.builtin.debug:
+#         msg: |
+#           CPU Configuration Status:
+#             - CPU Governor: {{ cpu_governor_check.stdout }}
+#             - CPU Scaling Driver: {{ pstate_check.stdout }}
+#             - AMD SMT/Hyperthreading: {{ smt_check.stdout }}
+
+#     # Assertions that will stop the playbook if they fail
+#     - name: Verify CPU governor is set to performance mode
+#       ansible.builtin.assert:
+#         that: cpu_governor_check.stdout == "performance"
+#         fail_msg: "ERROR! CPU governor is not set to performance mode. Current value: {{ cpu_governor_check.stdout }}"
+#         success_msg: "CPU governor correctly set to performance mode"
+
+#     - name: Verify CPU is using p-state driver
+#       ansible.builtin.assert:
+#         that: "'pstate' in pstate_check.stdout"
+#         fail_msg: "ERROR! CPU is not using p-state driver. Current driver: {{ pstate_check.stdout }}"
+#         success_msg: "CPU correctly using p-state driver: {{ pstate_check.stdout }}"
+
+#     - name: Verify AMD SMT/Hyperthreading is enabled
+#       ansible.builtin.assert:
+#         that: smt_check.stdout == "on"
+#         fail_msg: "ERROR! AMD SMT/Hyperthreading is not enabled. Current status: {{ smt_check.stdout }}"
+#         success_msg: "AMD SMT/Hyperthreading correctly enabled"
+
+- name: Check disk configuration for Solana servers
+  block:
+    # Get system disk information
+    - name: Get system disk
+      ansible.builtin.shell: |
+        root_disk=$(mount | grep ' / ' | awk '{print $1}' | sed 's/[0-9]*$//')
+        echo "$root_disk"
+      register: system_disk
+      changed_when: false
+      check_mode: false
+
+    # Check available disks
+    - name: Get disk information
+      ansible.builtin.shell: |
+        echo "=== Disk Information (sorted by size) ==="
+        printf "%-10s %-10s %-10s %-20s %-10s %-30s %s\n" "DEVICE" "SIZE" "TYPE" "MOUNTPOINT" "FSTYPE" "MODEL" "SERIAL"
+        echo "--------------------------------------------------------------------------------------------------------"
+        # Get disk information and sort by size
+        lsblk -b -d -o NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,MODEL,SERIAL | \
+        awk 'NR>1 {print $0}' | \
+        sort -k2 -nr | \
+        while read name size type mount fs model serial; do
+          size_human=$(numfmt --to=iec-i --suffix=B $size)
+          printf "%-10s %-10s %-10s %-20s %-10s %-30s %s\n" "$name" "$size_human" "$type" "$mount" "$fs" "$model" "$serial"
+        done
+      register: disk_info
+      changed_when: false
+      check_mode: false
+
+    # Display disk information
+    - name: Show disk information
+      ansible.builtin.debug:
+        msg: "{{ disk_info.stdout_lines }}"
+
+    # Get available disks (excluding system disk)
+    - name: Get available disks
+      ansible.builtin.shell: |
+        # Get disks sorted by size (excluding system disk)
+        lsblk -b -d -o NAME,SIZE | grep -v "NAME" | sort -k2 -nr | while read name size; do
+          if [ "$name" != "{{ system_disk.stdout | basename }}" ]; then
+            echo "$name"
+          fi
+        done
+      register: available_disks
+      changed_when: false
+      check_mode: false
+
+    # Store disk information for later use
+    - name: Store disk information
+      ansible.builtin.set_fact:
+        system_disk_name: "{{ system_disk.stdout | basename }}"
+        available_disks_list: "{{ available_disks.stdout_lines }}"
+        disk_info_detailed: "{{ disk_info.stdout_lines }}"
+
+    # Display verification results
+    - name: Display disk configuration status
+      ansible.builtin.debug:
+        msg: |
+          Disk Configuration Status:
+            System Disk: {{ system_disk_name }}
+
+            Available Disks:
+            {{ available_disks_list | join('\n') }}
+
+            Required Configuration:
+            - Ledger: {{ mount_points.ledger }} ({{ filesystem_formats.ledger }})
+            - Accounts: {{ mount_points.accounts }} ({{ filesystem_formats.accounts }})
+            - Snapshots: {{ mount_points.snapshots }} ({{ filesystem_formats.snapshots }})
+
+    # Assertions that will stop the playbook if they fail
+    - name: Verify minimum number of disks
+      ansible.builtin.assert:
+        that: available_disks_list | length >= min_required_disks
+        fail_msg: "ERROR! Insufficient number of disks. Need at least {{ min_required_disks }} disks for ledger, accounts, and snapshots."
+        success_msg: "Sufficient number of disks available (found {{ available_disks_list | length }}, required {{ min_required_disks }})"
+
+    - name: Verify mount points are NOT mounted
+      ansible.builtin.shell: |
+        mount | grep -E '{{ mount_points.ledger }}|{{ mount_points.accounts }}|{{ mount_points.snapshots }}' || true
+      register: mount_points_check
+      changed_when: false
+      check_mode: false
+
+    - name: Verify no existing mounts
+      ansible.builtin.assert:
+        that: mount_points_check.stdout_lines | length == 0
+        fail_msg: "ERROR! Found existing mounts for {{ mount_points.ledger }}, {{ mount_points.accounts }}, or {{ mount_points.snapshots }}. Please unmount these directories before proceeding."
+        success_msg: "No existing mounts found for required directories"

--- a/ansible/roles/server_initial_setup/tasks/system_tuning.yml
+++ b/ansible/roles/server_initial_setup/tasks/system_tuning.yml
@@ -1,0 +1,134 @@
+---
+# This role performs system tuning and optimization for Solana validator
+
+# CPU governor configuration
+- name: Upload CPU governor service
+  ansible.builtin.copy:
+    src: cpu-governor.service
+    dest: /etc/systemd/system/cpu-governor.service
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Enable and start CPU governor service
+  ansible.builtin.systemd:
+    name: cpu-governor
+    state: started
+    enabled: true
+    daemon_reload: true
+
+# File limits configuration
+- name: Upload sysctl file limits configuration
+  ansible.builtin.copy:
+    src: 21-agave-validator.conf
+    dest: /etc/sysctl.d/21-agave-validator.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Apply sysctl file limits configuration
+  ansible.builtin.command: sysctl -p /etc/sysctl.d/21-agave-validator.conf
+  changed_when: false
+
+- name: Configure system.conf file limits
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/system.conf
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - { regexp: '^#?DefaultLimitNOFILE=', line: 'DefaultLimitNOFILE=1000000' }
+    - { regexp: '^#?LimitNOFILE=', line: 'LimitNOFILE=1000000' }
+
+- name: Upload security limits configuration
+  ansible.builtin.copy:
+    src: 90-solana-nofiles.conf
+    dest: /etc/security/limits.d/90-solana-nofiles.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+# IPv6 deactivation
+- name: Upload IPv6 disable configuration
+  ansible.builtin.copy:
+    src: 99-disable-ipv6.conf
+    dest: /etc/sysctl.d/99-disable-ipv6.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Apply IPv6 disable configuration
+  ansible.builtin.command: sysctl -p /etc/sysctl.d/99-disable-ipv6.conf
+  changed_when: false
+
+# System Tuning Parameters
+- name: Update sysctl parameters
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: true
+    sysctl_set: true
+    sysctl_file: /etc/sysctl.d/99-system-tuning.conf
+  with_items:
+    # TCP Buffer Sizes
+    - { name: 'net.ipv4.tcp_rmem', value: '10240 87380 12582912' }
+    - { name: 'net.ipv4.tcp_wmem', value: '10240 87380 12582912' }
+    # Kernel Optimization
+    - { name: 'kernel.timer_migration', value: '0' }
+    - { name: 'kernel.hung_task_timeout_secs', value: '30' }
+    # Virtual Memory Settings
+    - { name: 'vm.swappiness', value: '30' }
+    - { name: 'vm.max_map_count', value: '2000000' }
+    - { name: 'vm.stat_interval', value: '10' }
+    - { name: 'vm.dirty_ratio', value: '40' }
+    - { name: 'vm.min_free_kbytes', value: '3000000' }
+    - { name: 'vm.dirty_expire_centisecs', value: '36000' }
+    - { name: 'vm.dirty_writeback_centisecs', value: '3000' }
+    # TCP Optimization
+    - { name: 'net.ipv4.tcp_congestion_control', value: 'westwood' }
+    - { name: 'net.ipv4.tcp_fastopen', value: '3' }
+    - { name: 'net.ipv4.tcp_timestamps', value: '0' }
+    - { name: 'net.ipv4.tcp_low_latency', value: '1' }
+    - { name: 'net.ipv4.tcp_tw_reuse', value: '1' }
+    - { name: 'net.ipv4.tcp_no_metrics_save', value: '1' }
+  register: sysctl_result
+
+- name: Verify that sysctl changes were applied
+  ansible.builtin.debug:
+    msg: "Updated sysctl parameters: {{ sysctl_result }}"
+
+# TCP Westwood Configuration
+- name: Check if congestion control algorithm is available
+  ansible.builtin.shell: "cat /proc/sys/net/ipv4/tcp_available_congestion_control | grep westwood"
+  register: check_westwood
+  changed_when: false
+
+- name: Load westwood module if needed
+  community.general.modprobe:
+    name: tcp_westwood
+    state: present
+  when: check_westwood.rc != 0
+
+- name: Ensure tcp_westwood loads at startup
+  ansible.builtin.lineinfile:
+    path: /etc/modules-load.d/westwood.conf
+    line: tcp_westwood
+    create: true
+    state: present
+    mode: '0644'
+    owner: root
+    group: root
+  when: check_westwood.rc != 0
+
+# Health Check Script
+- name: Copy health_check.sh to sol's home directory
+  ansible.builtin.copy:
+    src: "{{ health_check.script_name }}"
+    dest: "{{ health_check.dest_path }}"
+    owner: "{{ health_check.owner }}"
+    group: "{{ health_check.group }}"
+    mode: "{{ health_check.mode }}"

--- a/ansible/roles/server_initial_setup/vars/main.yml
+++ b/ansible/roles/server_initial_setup/vars/main.yml
@@ -1,0 +1,42 @@
+# Timezone configuration for the server
+timezone: "America/New_York"
+
+# User configuration for Solana validator
+sol_owner: "sol"
+
+# Directory permissions
+directory_permissions:
+  mode: '0755'
+  owner: "{{ sol_owner }}"
+  group: "{{ sol_owner }}"
+
+# Mount directories list
+mount_directories:
+  - ledger
+  - accounts
+  - snapshots
+
+# Disk configuration
+# Minimum number of disks required for validator setup
+min_required_disks: 3
+
+# Mount points
+mount_points:
+  ledger: "/mnt/ledger"      # For ledger data (largest disk)
+  accounts: "/mnt/accounts"  # For accounts data (second largest)
+  snapshots: "/mnt/snapshots" # For snapshots (third largest)
+
+# Filesystem formats for each component
+filesystem_formats:
+  ledger: "xfs"    # High-performance filesystem for ledger
+  accounts: "xfs"  # High-performance filesystem for accounts
+  snapshots: "ext4" # Standard filesystem for snapshots
+
+# Health check configuration
+# Script to monitor validator health
+health_check:
+  script_name: "health_check.sh"
+  dest_path: "/home/{{ sol_owner }}/{{ health_check.script_name }}"
+  owner: "{{ sol_owner }}"
+  group: "{{ sol_owner }}"
+  mode: "0750"


### PR DESCRIPTION
# Initial Server Configuration Role - First Phase

This pull request introduces the initial scaffold for a new role responsible for configuring hardware and system settings on the server.

## Summary of Changes

- Added initial structure for the new role: `server_initial_setup`
- Created a new playbook: `pb_setup_metal_box.yml` to invoke the role
- Defined essential variables for this phase
- Implemented preliminary roles:
  - **`precheck`**: Validates that the playbook is being executed on the correct target server

## New Validations and Enhancements

- A validation mechanism was added in the `precheck` role to **fail the playbook execution** if any of the following mount points are detected:
  - `/accounts`
  - `/ledger`
  - `/snapshots`

  This prevents running the setup on an already active validator  box.

## Testing

- Tests were performed on a **VirtualBox-based virtual environment** emulating 3 NVMe disks
- The playbook successfully:
  - Detected and formatted the disks
  - Mounted them appropriately

## Next Steps

- The current implementation is in a consolidation phase
- Further testing will be conducted in more environments, including bare-metal, to ensure its works in real scenario