### PR TITLE
Changes during testnet upgrade to v2.2.16

### DIFF
--- a/ansible/group_vars/city_losangeles.yml
+++ b/ansible/group_vars/city_losangeles.yml
@@ -1,0 +1,3 @@
+jito_mainnet_block_engine_city: "dallas"
+jito_testnet_block_engine_city: "dallas"
+jito_localnet_block_engine_city: "dallas"

--- a/ansible/solana_setup_host.yml
+++ b/ansible/solana_setup_host.yml
@@ -1,26 +1,26 @@
 all:
   hosts:
-    hyk-edg-mia:
-      ansible_host: 45.77.74.20
+    hyk-lat-dal:
+      ansible_host: 67.213.118.77
       ansible_port: 2522
 
   children:
     # ───── Data Center Grouping ─────
-    dc_edgevana:
+    dc_latitude:
       hosts:
-        hyk-edg-mia:
+        hyk-lat-dal:
 
     # ───── City Grouping ─────
-    city_miami:
+    city_dallas:
       hosts:
-        hyk-edg-mia:
+        hyk-lat-dal:
 
     # ───── Network Grouping ─────
     solana:
       hosts:
-        hyk-edg-mia:
+        hyk-lat-dal:
 
     # ───── Solana Cluster Grouping ─────
-    solana_mainnet:
+    solana_testnet:
       hosts:
-        hyk-edg-mia:
+        hyk-lat-dal:

--- a/ansible/solana_testnet.yml
+++ b/ansible/solana_testnet.yml
@@ -4,8 +4,8 @@ all:
     hyk-lat-dal:
       ansible_host: 67.213.118.77
       ansible_port: 2522
-    hyk-lat-dal2:
-      ansible_host: 72.46.85.173
+    hyk-lat-lax:
+      ansible_host: 103.219.170.119
       ansible_port: 2522
 
   children:
@@ -13,22 +13,22 @@ all:
     dc_latitude:
       hosts:
         hyk-lat-dal:
-        hyk-lat-dal2:
+        hyk-lat-lax:
 
     # ───── City Grouping ─────
     city_dallas:
       hosts:
         hyk-lat-dal:
-        hyk-lat-dal2:
+        hyk-lat-lax:
 
     # ───── Network Grouping ─────
     solana:
       hosts:
         hyk-lat-dal:
-        hyk-lat-dal2:
+        hyk-lat-lax:
 
     # ───── Solana Cluster Grouping ─────
     solana_testnet:
       hosts:
         hyk-lat-dal:
-        hyk-lat-dal2:
+        hyk-lat-lax:


### PR DESCRIPTION
Changes:
- Added new city group var for Los Angeles. (It didn't go well with city_los_angeles)
- Updated required inventories for setup los angeles host `hyk-lat-lax `

> NOTE: We could not upgrade to v2.3.0 because the Jito client release for v2.3.0 was not yet ready. We at least satisfied the minimum version requirement for testnet (v2.2.16).