### PR TITLE
Fix logrotate configuration for new host setups

### DIFF
--- a/ansible/roles/solana_validator_jito/tasks/host_cleanup.yml
+++ b/ansible/roles/solana_validator_jito/tasks/host_cleanup.yml
@@ -13,6 +13,7 @@
 
     echo "Cleaning snapshots directory..."
     rm -rf {{ snapshots_path }}/*
+  delegate_to: "{{ target_host }}"
 
 - name: Ensure ledger directory exists
   ansible.builtin.file:
@@ -22,6 +23,7 @@
     owner: "{{ solana_user }}"
     group: "{{ solana_user }}"
   become: true
+  delegate_to: "{{ target_host }}"
 
 - name: Ensure accounts directory exists
   ansible.builtin.file:
@@ -31,6 +33,7 @@
     owner: "{{ solana_user }}"
     group: "{{ solana_user }}"
   become: true
+  delegate_to: "{{ target_host }}"
 
 - name: Ensure snapshots directory exists
   ansible.builtin.file:
@@ -40,3 +43,4 @@
     owner: "{{ solana_user }}"
     group: "{{ solana_user }}"
   become: true
+  delegate_to: "{{ target_host }}"

--- a/ansible/roles/solana_validator_jito/tasks/jito_client/configure/config_logrotate.yml
+++ b/ansible/roles/solana_validator_jito/tasks/jito_client/configure/config_logrotate.yml
@@ -19,3 +19,32 @@
     - name: Fail with error message
       ansible.builtin.fail:
         msg: "Failed to configure validator log rotation. Error: {{ ansible_failed_result }}"
+
+- name: Set up validator logrotate systemd timer (localnet only)
+  block:
+    - name: Deploy validator logrotate systemd service
+      ansible.builtin.template:
+        src: validator-logrotate.service.j2
+        dest: /etc/systemd/system/validator-logrotate.service
+        mode: "0644"
+      become: true
+
+    - name: Deploy validator logrotate systemd timer
+      ansible.builtin.template:
+        src: validator-logrotate.timer.j2
+        dest: /etc/systemd/system/validator-logrotate.timer
+        mode: "0644"
+      become: true
+
+    - name: Reload systemd to pick up new timer
+      ansible.builtin.systemd:
+        daemon_reload: true
+      become: true
+
+    - name: Enable and start validator logrotate timer
+      ansible.builtin.systemd:
+        name: validator-logrotate.timer
+        enabled: true
+        state: started
+      become: true
+  when: solana_cluster == 'localnet'

--- a/ansible/roles/solana_validator_jito/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_jito/tasks/prepare.yml
@@ -32,6 +32,29 @@
 - name: Stop and remove relayer service if exists
   import_tasks: jito_relayer_cohosted/stop_service.yml
 
+- name: Remove old validator logrotate config if it exists
+  ansible.builtin.file:
+    path: /etc/logrotate.d/validator.logrotate
+    state: absent
+  become: true
+  delegate_to: "{{ target_host }}"
+
+- name: Remove old validator logrotate systemd service if it exists (localnet only)
+  ansible.builtin.file:
+    path: /etc/systemd/system/validator-logrotate.service
+    state: absent
+  become: true
+  when: solana_cluster == 'localnet'
+  delegate_to: "{{ target_host }}"
+
+- name: Remove old validator logrotate systemd timer if it exists (localnet only)
+  ansible.builtin.file:
+    path: /etc/systemd/system/validator-logrotate.timer
+    state: absent
+  become: true
+  when: solana_cluster == 'localnet'
+  delegate_to: "{{ target_host }}"
+
 - name: Clear logs and key store
   ansible.builtin.shell: |
     #!/bin/bash
@@ -45,6 +68,7 @@
 
     echo "Cleaning keys directory..."
     rm -rf {{ keys_dir }}/*
+  delegate_to: "{{ target_host }}"
 
 - name: Ensure logs directory exists
   ansible.builtin.file:

--- a/ansible/roles/solana_validator_jito/templates/validator-logrotate.service.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator-logrotate.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Logrotate for validator logs
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate -f /etc/logrotate.d/validator.logrotate

--- a/ansible/roles/solana_validator_jito/templates/validator-logrotate.timer.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator-logrotate.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run validator logrotate every hour
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/solana_validator_jito/templates/validator.logrotate.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator.logrotate.j2
@@ -1,10 +1,13 @@
 {{ logs_dir }}/agave-validator.log {
   rotate 1
-  daily
+  {% if solana_cluster == 'localnet' %}
+  size 10M
+  {% else %}
   size 1G
+  {% endif %}
   compress
   missingok
   postrotate
-    systemctl kill -s USR1 agave-validator.service
+    systemctl kill -s USR1 sol.service
   endscript
 }

--- a/ansible/roles/solana_validator_jito/templates/validator.logrotate.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator.logrotate.j2
@@ -1,7 +1,7 @@
 {{ logs_dir }}/agave-validator.log {
   rotate 1
   {% if solana_cluster == 'localnet' %}
-  size 10M
+  size 100M
   {% else %}
   size 1G
   {% endif %}

--- a/ansible/roles/solana_validator_jito/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator.startup.j2
@@ -4,7 +4,7 @@ PATH="/bin:/usr/bin:{{ solana_install_dir }}"
 {% if solana_metrics_url is defined and solana_metrics_url != None and solana_metrics_url != '' %}
 export SOLANA_METRICS_CONFIG="host={{ solana_metrics_url }}"
 {% endif %}
-agave-validator \
+exec agave-validator \
 --identity {{ validator_keys_dir }}/identity.json \
 --vote-account {{ vote_account_pubkey }} \
 --authorized-voter {{ validator_keys_dir }}/primary-target-identity.json \

--- a/solana-localnet/Dockerfile
+++ b/solana-localnet/Dockerfile
@@ -23,7 +23,9 @@ RUN rm -rf /var/lib/apt/lists/* && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
        apt-utils \
+       cron \
        locales \
+       logrotate \
        python3-dev \
        python3-setuptools \
        python3-pip \

--- a/solana-localnet/start-localnet.sh
+++ b/solana-localnet/start-localnet.sh
@@ -91,7 +91,7 @@ ENTRYPOINT_IDENTITY_PUBKEY=$(solana -ul validators --keep-unstaked-delinquents -
 
 ANSIBLE_VALIDATORS_KEYS_DIR=/hayek-validator-kit/solana-localnet/validator-keys
 ANSIBLE_CANOPY_KEYS_DIR="$ANSIBLE_VALIDATORS_KEYS_DIR/canopy"
-ALPHA_CANOPY_KEYS_DIR="/home/sol/keys/canopy-localnet"
+ALPHA_CANOPY_KEYS_DIR="/home/sol/keys/canopy"
 # We have the CANOPY SERVER BOX
 # We have the CANOPY VALIDATOR KEY SET
 # We could have the SEED VALIDATOR KEY SET deployed on the CANOPY SERVER BOX


### PR DESCRIPTION
- Fixed logrotate configuration to send signal to the correct service unit
- Added `exec` keyword to launch `agave-validator` process
   More on this here: [Using logrotate](https://docs.anza.xyz/operations/guides/validator-start#logging)
- Tweaked `host_cleanup.yml` to delegate operation only to `target_host`
- Added a custom timer configuration for triggering logrotate on localnet hosts (1 hour timeout)
   Added `cron` and `logrotate` to Dockerfile to have them available in the localnet hosts
- Ensure services are stopped and logrotate configs removed before starting setup
- Fixed a pending leftover for `host-alpha` keys directory naming
