### PR TITLE
Add expected-shred-version param for testnet

### DIFF
--- a/ansible/group_vars/solana_testnet.yml
+++ b/ansible/group_vars/solana_testnet.yml
@@ -26,6 +26,8 @@ restart_min_idle_time: 5
 # Maximum percentage of credits loss allowed for automatic deprovisioning of source host
 credits_loss_threshold: 4
 
+expected_shred_version: 9065
+
 solana_gossip_entrypoints:
   - entrypoint.testnet.solana.com:8001
   - entrypoint2.testnet.solana.com:8001

--- a/ansible/roles/solana_validator_jito/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator.startup.j2
@@ -14,6 +14,9 @@ exec agave-validator \
 {% if only_known_rpc is defined and only_known_rpc %}
 --only-known-rpc \
 {% endif %}
+{% if solana_cluster == "testnet" and expected_shred_version is defined %}
+--expected-shred-version {{ expected_shred_version }} \
+{% endif %}
 --ledger {{ ledger_path }} \
 --accounts {{ accounts_path }} \
 --snapshots {{ snapshots_path }} \


### PR DESCRIPTION
- Make expected_shred_version a setting for easy updates after each cluster restart
- Add --expected-shred-version parameter to validator startup script with expected_shred_version