### PR TITLE
79 create playbook for installing agave

### DIFF
--- a/ansible/group_vars/solana.yml
+++ b/ansible/group_vars/solana.yml
@@ -25,6 +25,11 @@ snapshots_path: "{{ mount_base_path }}/snapshots"
 # Solana service settings
 snapshot_interval_slots: 0 # 0 means no snapshots are taken
 
+# Logging configuration
+logrotate_max_size: "1G"
+logrotate_rotate_count: 1
+logrotate_schedule: "daily"
+
 # Solana service network settings
 solana_rpc_port: 8899 # RPC port
 open_solana_ports_start: 8000 # Start of the range of ports to open for Solana services

--- a/ansible/group_vars/solana_localnet.yml
+++ b/ansible/group_vars/solana_localnet.yml
@@ -35,3 +35,6 @@ jito_tip_payment_program_pubkey: "GJHtFqM9agxPmkeKjHny6qiRKrXZALvvFGiKf11QE7hy"
 jito_tip_distribution_program_pubkey: "F2Zu7QZiTYUhPd7u9ukRVwxh7B71oA3NMJcHuCHc29P2"
 jito_merkle_root_upload_authority: "GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib"
 jito_commission_bps: 0
+
+# Logging configuration
+logrotate_max_size_localnet: "100M"

--- a/ansible/playbooks/pb_setup_validator_agave.yml
+++ b/ansible/playbooks/pb_setup_validator_agave.yml
@@ -1,0 +1,92 @@
+---
+# Agave Validator Setup
+# -------------------
+# Sets up a Solana validator with Agave client.
+#
+# Usage:
+# ------
+# Run from /ansible directory:
+#
+# syntax check
+# ansible-playbook playbooks/pb_setup_validator_agave.yml
+#   -i solana_localnet.yml \
+#   --limit host-charlie \
+#   --syntax-check \
+#   -e "target_host=host-charlie"
+#
+# ansible-playbook playbooks/pb_setup_validator_agave.yml \
+#   -i solana_localnet.yml \
+#   --limit host-charlie \
+#   -e "target_host=host-charlie" \
+#   -e "validator_name=penny" \
+#   -e "validator_type=hot-spare" \
+#   -e "agave_version=2.3.6" \
+#   -e "solana_cluster=localnet" \
+#   -e "build_from_source=true" \ # Optional: Build from source instead of using precompiled binaries
+#   -e "use_official_repo=true" \ # Optional: Use official repository instead of forked repository
+#   -e "force_host_cleanup=true" \ # Optional: Use if target host is running a validator in a different cluster
+
+- name: Install Agave Validator
+  hosts: "{{ target_host }}"
+  user: "{{ solana_user }}"
+  become: false
+
+  pre_tasks:
+    - name: Assert required parameters are defined
+      ansible.builtin.assert:
+        that:
+          - target_host is defined
+          - validator_name is defined
+          - validator_type is defined
+          - agave_version is defined
+          - solana_cluster is defined
+        fail_msg: >
+          Missing required variables.
+          Must provide:
+            - target_host
+            - validator_name
+            - validator_type
+            - agave_version
+            - solana_cluster
+          Optional:
+            - build_from_source (set to true to build from source)
+            - use_official_repo (set to true to use official repository)
+            - force_host_cleanup (set to true to force stop existing validator service)
+
+    - name: Debug ansible_limit and target_host
+      ansible.builtin.debug:
+        msg:
+          - "ansible_limit: {{ ansible_limit | default('not defined') }}"
+          - "ansible_limit type: {{ ansible_limit | type_debug }}"
+          - "target_host: {{ target_host }}"
+          - "ansible_play_hosts: {{ ansible_play_hosts }}"
+
+    - name: Validate that target_host matches the limited host
+      ansible.builtin.assert:
+        that:
+          - ansible_limit is defined
+          - target_host == ansible_limit
+        fail_msg: >
+          This playbook must be run with --limit to target exactly one host.
+          Make sure you run this playbook with: --limit {{ target_host }} -e "target_host={{ target_host }}"
+
+    - name: Validate validator_type value
+      ansible.builtin.assert:
+        that:
+          - validator_type in ['primary', 'hot-spare']
+        fail_msg: "Invalid validator_type '{{ validator_type }}'. Must be 'primary' or 'hot-spare'."
+
+    - name: Validate agave_version format
+      ansible.builtin.assert:
+        that:
+          - agave_version is regex('^[0-9]+\.[0-9]+\.[0-9]+$')
+        fail_msg: "Invalid agave_version '{{ agave_version }}'. Must follow semantic versioning pattern (e.g. 1.2.3)."
+
+    - name: Validate solana_cluster value
+      ansible.builtin.assert:
+        that:
+          - solana_cluster in ['localnet', 'testnet', 'mainnet']
+        fail_msg: "Invalid solana_cluster '{{ solana_cluster }}'. Must be 'localnet', 'testnet', or 'mainnet'."
+
+  roles:
+    - role: solana_validator_agave

--- a/ansible/roles/common/tasks/check_minimum_disk_space.yml
+++ b/ansible/roles/common/tasks/check_minimum_disk_space.yml
@@ -1,0 +1,43 @@
+---
+# Check if there is sufficient disk space in the given user directory
+- name: Get initial disk space
+  ansible.builtin.shell: |
+    df -h "{{ solana_user_dir }}" | awk 'NR==2 {print $4}'
+  register: initial_space
+  changed_when: false
+
+- name: Print initial available space
+  ansible.builtin.debug:
+    msg: "Initial available space in /home/sol: {{ initial_space.stdout }}"
+
+- name: Set minimum required space (experimental)
+  ansible.builtin.set_fact:
+    min_required_space: "14G"  # This is an initial estimate, can be adjusted based on experience
+
+- name: Convert space to bytes for comparison
+  ansible.builtin.set_fact:
+    initial_space_bytes: >-
+      {% set size = initial_space.stdout | regex_replace('^([0-9.]+)\\s*([KMG])$', '\\1') | float %}
+      {% set unit = initial_space.stdout | regex_replace('^[0-9.]+\\s*([KMG])$', '\\1') %}
+      {% if unit == 'K' %}
+        {{ (size * 1024) | int }}
+      {% elif unit == 'M' %}
+        {{ (size * 1024 * 1024) | int }}
+      {% elif unit == 'G' %}
+        {{ (size * 1024 * 1024 * 1024) | int }}
+      {% endif %}
+    min_required_bytes: >-
+      {% set size = min_required_space | regex_replace('^([0-9.]+)\\s*([KMG])$', '\\1') | float %}
+      {% set unit = min_required_space | regex_replace('^[0-9.]+\\s*([KMG])$', '\\1') %}
+      {% if unit == 'K' %}
+        {{ (size * 1024) | int }}
+      {% elif unit == 'M' %}
+        {{ (size * 1024 * 1024) | int }}
+      {% elif unit == 'G' %}
+        {{ (size * 1024 * 1024 * 1024) | int }}
+      {% endif %}
+
+- name: Check if available space is sufficient
+  ansible.builtin.fail:
+    msg: "Insufficient disk space. Available: {{ initial_space.stdout }}, Minimum required: {{ min_required_space }}"
+  when: initial_space_bytes | int < min_required_bytes | int

--- a/ansible/roles/solana_validator_agave/defaults/main.yml
+++ b/ansible/roles/solana_validator_agave/defaults/main.yml
@@ -1,9 +1,0 @@
----
-# Agave Validator Default Configuration
-# ------------------------------------
-
-# Logging configuration
-logrotate_max_size: "1G"
-logrotate_max_size_localnet: "100M"
-logrotate_rotate_count: 1
-logrotate_schedule: "daily"

--- a/ansible/roles/solana_validator_agave/defaults/main.yml
+++ b/ansible/roles/solana_validator_agave/defaults/main.yml
@@ -3,6 +3,7 @@
 # ------------------------------------
 
 # Logging configuration
-logrotate_max_size: "100M"
-logrotate_rotate_count: 5
+logrotate_max_size: "1G"
+logrotate_max_size_localnet: "100M"
+logrotate_rotate_count: 1
 logrotate_schedule: "daily"

--- a/ansible/roles/solana_validator_agave/defaults/main.yml
+++ b/ansible/roles/solana_validator_agave/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# Agave Validator Default Configuration
+# ------------------------------------
+
+# Logging configuration
+logrotate_max_size: "100M"
+logrotate_rotate_count: 5
+logrotate_schedule: "daily"

--- a/ansible/roles/solana_validator_agave/meta/argument_specs.yml
+++ b/ansible/roles/solana_validator_agave/meta/argument_specs.yml
@@ -1,0 +1,43 @@
+---
+argument_specs:
+  main:
+    short_description: "Install Agave Solana validator"
+    author: "Hayek Validator Team"
+    description:
+      - "Installs and configures an Agave Solana validator"
+      - "Automatically installs dependencies (rust_env, solana_cli, solana_validator_shared)"
+      - "Configures validator keys and startup scripts"
+    options:
+      validator_name:
+        type: str
+        required: true
+        description: "Name of the validator instance"
+      validator_type:
+        type: str
+        required: true
+        choices: ["primary", "hot-spare"]
+        description: "Type of validator (primary or hot-spare)"
+      agave_version:
+        type: str
+        required: true
+        description: "Version of Agave to install (semantic versioning, e.g. 2.3.6)"
+      solana_cluster:
+        type: str
+        required: true
+        choices: ["localnet", "testnet", "mainnet"]
+        description: "Target Solana cluster"
+      force_host_cleanup:
+        type: bool
+        required: false
+        default: false
+        description: "Force cleanup of existing validator data"
+      build_from_source:
+        type: bool
+        required: false
+        default: false
+        description: "Build from source instead of using precompiled binaries"
+      use_official_repo:
+        type: bool
+        required: false
+        default: false
+        description: "Use official repository instead of forked repository when building from source"

--- a/ansible/roles/solana_validator_agave/meta/main.yml
+++ b/ansible/roles/solana_validator_agave/meta/main.yml
@@ -2,6 +2,11 @@
 dependencies:
   - role: rust_env
   - role: solana_cli
+    vars:
+      agave_version: "{{ agave_version }}"
+      build_from_source: "{{ build_from_source | default(false) }}"
+      use_official_repo: "{{ use_official_repo | default(false) }}"
   - role: solana_validator_shared
     vars:
       validator_name: "{{ validator_name }}"
+      validator_type: "{{ validator_type }}"

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -71,11 +71,11 @@
         group: "{{ solana_user }}"
       ignore_errors: "{{ ansible_check_mode }}"
   rescue:
-    - name: configure - configure - Fail with error message
+    - name: configure - Fail with error message
       ansible.builtin.fail:
         msg: "Failed to configure validator startup script. Error: {{ ansible_failed_result }}"
 
-- name: configure - configure - Configure validator log rotation
+- name: configure - Configure validator log rotation
   block:
     - name: configure - Create logrotate configuration
       ansible.builtin.template:

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -1,62 +1,162 @@
 ---
-- name: Create validator startup script
-  ansible.builtin.template:
-    src: validator.startup.j2
-    dest: "{{ validator_script_path }}"
-    owner: "{{ solana_user }}"
-    group: "{{ solana_user }}"
-    mode: '0755'
+- name: Set validator_keyset_name default if not defined
+  ansible.builtin.set_fact:
+    validator_keyset_name: "{{ validator_name }}"
+  when: validator_keyset_name is not defined
 
-- name: Create validator systemd service
-  ansible.builtin.template:
-    src: validator.service.j2
-    dest: "/etc/systemd/system/{{ validator_service_name }}.service"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
+- name: Install validator keyset using shared task
+  ansible.builtin.import_tasks: ../../solana_validator_shared/tasks/install_validator_keyset.yml
 
-- name: Create logrotate configuration
-  ansible.builtin.template:
-    src: validator.logrotate.j2
-    dest: "/etc/logrotate.d/{{ validator_service_name }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
+- name: Set validator script path
+  ansible.builtin.set_fact:
+    validator_script_path: "{{ scripts_dir }}/run-{{ validator_name }}.sh"
 
-- name: Create logrotate service
-  ansible.builtin.template:
-    src: validator-logrotate.service.j2
-    dest: "/etc/systemd/system/{{ validator_service_name }}-logrotate.service"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
+- name: Configure validator startup script
+  block:
+    - name: Get vote account pubkey
+      block:
+        - name: Get vote account public key
+          ansible.builtin.command: solana address -k {{ ansible_keys_dir }}/vote-account.json
+          register: vote_account_cmd
+          delegate_to: localhost
 
-- name: Create logrotate timer
-  ansible.builtin.template:
-    src: validator-logrotate.timer.j2
-    dest: "/etc/systemd/system/{{ validator_service_name }}-logrotate.timer"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
+        - name: Set vote account public key
+          ansible.builtin.set_fact:
+            vote_account_pubkey: "{{ vote_account_cmd.stdout }}"
 
-- name: Reload systemd daemon
-  ansible.builtin.systemd:
-    daemon_reload: true
-  become: true
+    - name: Get localnet genesis hash
+      block:
+        - name: Get genesis hash
+          ansible.builtin.command: solana -ul genesis-hash
+          register: cluster_genesis_hash
+          delegate_to: localhost
 
-- name: Enable and start validator service
-  ansible.builtin.systemd:
-    name: "{{ validator_service_name }}"
-    state: started
-    enabled: true
+        - name: Set expected genesis hash
+          ansible.builtin.set_fact:
+            expected_genesis_hash: "{{ cluster_genesis_hash.stdout }}"
 
-- name: Enable logrotate timer
-  ansible.builtin.systemd:
-    name: "{{ validator_service_name }}-logrotate.timer"
-    state: started
-    enabled: true
-  become: true
+        - name: Get entrypoint identity pubkey
+          ansible.builtin.shell: solana -ul validators --keep-unstaked-delinquents --output json | jq -r ".validators | .[0].identityPubkey"
+          register: entrypoint_identity_cmd
+          delegate_to: localhost
+
+        - name: Add entrypoint to known validators
+          ansible.builtin.set_fact:
+            known_validators: "{{ known_validators + [entrypoint_identity_cmd.stdout] }}"
+      when: solana_cluster == "localnet"
+
+    - name: Create validator startup script
+      ansible.builtin.template:
+        src: validator.startup.j2
+        dest: "{{ validator_script_path }}"
+        owner: "{{ solana_user }}"
+        group: "{{ solana_user }}"
+        mode: "0755"
+
+    - name: Copy fix_core_afinity_bug_for_poh.sh script to remote
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../scripts/fix_core_afinity_bug_for_poh.sh"
+        dest: "{{ scripts_dir }}"
+        mode: "0755"
+        owner: "{{ solana_user }}"
+        group: "{{ solana_user }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+
+    - name: Copy schedule_set_hot_spare_identity.sh script to remote
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../scripts/schedule_set_hot_spare_identity.sh"
+        dest: "{{ scripts_dir }}"
+        mode: "0755"
+        owner: "{{ solana_user }}"
+        group: "{{ solana_user }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+  rescue:
+    - name: Fail with error message
+      ansible.builtin.fail:
+        msg: "Failed to configure validator startup script. Error: {{ ansible_failed_result }}"
+
+- name: Configure validator log rotation
+  block:
+    - name: Create logrotate configuration
+      ansible.builtin.template:
+        src: validator.logrotate.j2
+        dest: "/etc/logrotate.d/{{ validator_service_name }}"
+        mode: "0644"
+      become: true
+
+    - name: Verify logrotate configuration
+      ansible.builtin.command: logrotate -d /etc/logrotate.d/{{ validator_service_name }}
+      register: logrotate_check
+      changed_when: false
+      failed_when: false
+      become: true
+
+  rescue:
+    - name: Fail with error message
+      ansible.builtin.fail:
+        msg: "Failed to configure validator log rotation. Error: {{ ansible_failed_result }}"
+
+- name: Set up validator logrotate systemd timer (localnet only)
+  block:
+    - name: Deploy validator logrotate systemd service
+      ansible.builtin.template:
+        src: validator-logrotate.service.j2
+        dest: /etc/systemd/system/validator-logrotate.service
+        mode: "0644"
+      become: true
+
+    - name: Deploy validator logrotate systemd timer
+      ansible.builtin.template:
+        src: validator-logrotate.timer.j2
+        dest: /etc/systemd/system/validator-logrotate.timer
+        mode: "0644"
+      become: true
+
+    - name: Reload systemd to pick up new timer
+      ansible.builtin.systemd:
+        daemon_reload: true
+      become: true
+
+    - name: Enable and start validator logrotate timer
+      ansible.builtin.systemd:
+        name: validator-logrotate.timer
+        enabled: true
+        state: started
+      become: true
+  when: solana_cluster == 'localnet'
+
+- name: Configure validator systemd service
+  block:
+    - name: Create systemd service directory
+      ansible.builtin.file:
+        path: /etc/systemd/system
+        state: directory
+        mode: "0755"
+      become: true
+
+    - name: Create validator systemd service
+      ansible.builtin.template:
+        src: validator.service.j2
+        dest: "/etc/systemd/system/{{ validator_service_name }}.service"
+        mode: "0644"
+      become: true
+
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true
+      become: true
+
+    - name: Enable validator service
+      ansible.builtin.systemd:
+        name: "{{ validator_service_name }}"
+        enabled: true
+        state: started
+      become: true
+  rescue:
+    - name: Fail with error message
+      ansible.builtin.fail:
+        msg: "Failed to configure validator systemd service. Error: {{ ansible_failed_result }}"
+
+- name: Configuration complete
+  ansible.builtin.debug:
+    msg: "Agave validator configuration completed successfully"

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -1,0 +1,62 @@
+---
+- name: Create validator startup script
+  ansible.builtin.template:
+    src: validator.startup.j2
+    dest: "{{ validator_script_path }}"
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+    mode: '0755'
+
+- name: Create validator systemd service
+  ansible.builtin.template:
+    src: validator.service.j2
+    dest: "/etc/systemd/system/{{ validator_service_name }}.service"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Create logrotate configuration
+  ansible.builtin.template:
+    src: validator.logrotate.j2
+    dest: "/etc/logrotate.d/{{ validator_service_name }}"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Create logrotate service
+  ansible.builtin.template:
+    src: validator-logrotate.service.j2
+    dest: "/etc/systemd/system/{{ validator_service_name }}-logrotate.service"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Create logrotate timer
+  ansible.builtin.template:
+    src: validator-logrotate.timer.j2
+    dest: "/etc/systemd/system/{{ validator_service_name }}-logrotate.timer"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+
+- name: Enable and start validator service
+  ansible.builtin.systemd:
+    name: "{{ validator_service_name }}"
+    state: started
+    enabled: true
+
+- name: Enable logrotate timer
+  ansible.builtin.systemd:
+    name: "{{ validator_service_name }}-logrotate.timer"
+    state: started
+    enabled: true
+  become: true

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -1,51 +1,51 @@
 ---
-- name: Set validator_keyset_name default if not defined
+- name: configure - Set validator_keyset_name default if not defined
   ansible.builtin.set_fact:
     validator_keyset_name: "{{ validator_name }}"
   when: validator_keyset_name is not defined
 
-- name: Install validator keyset using shared task
+- name: configure - Install validator keyset using shared task
   ansible.builtin.import_tasks: ../../solana_validator_shared/tasks/install_validator_keyset.yml
 
-- name: Set validator script path
+- name: configure - Set validator script path
   ansible.builtin.set_fact:
     validator_script_path: "{{ scripts_dir }}/run-{{ validator_name }}.sh"
 
-- name: Configure validator startup script
+- name: configure - Configure validator startup script
   block:
-    - name: Get vote account pubkey
+    - name: configure - Get vote account pubkey
       block:
-        - name: Get vote account public key
-          ansible.builtin.command: solana address -k {{ ansible_keys_dir }}/vote-account.json
+        - name: configure - Get vote account public key
+          ansible.builtin.command: solana-keygen pubkey {{ ansible_home_dir }}/.validator-keys/{{ validator_name }}/vote-account.json
           register: vote_account_cmd
           delegate_to: localhost
 
-        - name: Set vote account public key
+        - name: configure - Set vote account public key
           ansible.builtin.set_fact:
             vote_account_pubkey: "{{ vote_account_cmd.stdout }}"
 
-    - name: Get localnet genesis hash
+    - name: configure - Get localnet genesis hash
       block:
-        - name: Get genesis hash
+        - name: configure - Get genesis hash
           ansible.builtin.command: solana -ul genesis-hash
           register: cluster_genesis_hash
           delegate_to: localhost
 
-        - name: Set expected genesis hash
+        - name: configure - Set expected genesis hash
           ansible.builtin.set_fact:
             expected_genesis_hash: "{{ cluster_genesis_hash.stdout }}"
 
-        - name: Get entrypoint identity pubkey
+        - name: configure - Get entrypoint identity pubkey
           ansible.builtin.shell: solana -ul validators --keep-unstaked-delinquents --output json | jq -r ".validators | .[0].identityPubkey"
           register: entrypoint_identity_cmd
           delegate_to: localhost
 
-        - name: Add entrypoint to known validators
+        - name: configure - Add entrypoint to known validators
           ansible.builtin.set_fact:
             known_validators: "{{ known_validators + [entrypoint_identity_cmd.stdout] }}"
       when: solana_cluster == "localnet"
 
-    - name: Create validator startup script
+    - name: configure - Create validator startup script
       ansible.builtin.template:
         src: validator.startup.j2
         dest: "{{ validator_script_path }}"
@@ -53,7 +53,7 @@
         group: "{{ solana_user }}"
         mode: "0755"
 
-    - name: Copy fix_core_afinity_bug_for_poh.sh script to remote
+    - name: configure - Copy fix_core_afinity_bug_for_poh.sh script to remote
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../scripts/fix_core_afinity_bug_for_poh.sh"
         dest: "{{ scripts_dir }}"
@@ -62,7 +62,7 @@
         group: "{{ solana_user }}"
       ignore_errors: "{{ ansible_check_mode }}"
 
-    - name: Copy schedule_set_hot_spare_identity.sh script to remote
+    - name: configure - Copy schedule_set_hot_spare_identity.sh script to remote
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../scripts/schedule_set_hot_spare_identity.sh"
         dest: "{{ scripts_dir }}"
@@ -71,20 +71,20 @@
         group: "{{ solana_user }}"
       ignore_errors: "{{ ansible_check_mode }}"
   rescue:
-    - name: Fail with error message
+    - name: configure - configure - Fail with error message
       ansible.builtin.fail:
         msg: "Failed to configure validator startup script. Error: {{ ansible_failed_result }}"
 
-- name: Configure validator log rotation
+- name: configure - configure - Configure validator log rotation
   block:
-    - name: Create logrotate configuration
+    - name: configure - Create logrotate configuration
       ansible.builtin.template:
         src: validator.logrotate.j2
         dest: "/etc/logrotate.d/{{ validator_service_name }}"
         mode: "0644"
       become: true
 
-    - name: Verify logrotate configuration
+    - name: configure - Verify logrotate configuration
       ansible.builtin.command: logrotate -d /etc/logrotate.d/{{ validator_service_name }}
       register: logrotate_check
       changed_when: false
@@ -92,71 +92,71 @@
       become: true
 
   rescue:
-    - name: Fail with error message
+    - name: configure - Fail with error message
       ansible.builtin.fail:
         msg: "Failed to configure validator log rotation. Error: {{ ansible_failed_result }}"
 
-- name: Set up validator logrotate systemd timer (localnet only)
+- name: configure - Set up validator logrotate systemd timer (localnet only)
   block:
-    - name: Deploy validator logrotate systemd service
+    - name: configure - Deploy validator logrotate systemd service
       ansible.builtin.template:
         src: validator-logrotate.service.j2
-        dest: /etc/systemd/system/validator-logrotate.service
+        dest: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.service"
         mode: "0644"
       become: true
 
-    - name: Deploy validator logrotate systemd timer
+    - name: configure - Deploy validator logrotate systemd timer
       ansible.builtin.template:
         src: validator-logrotate.timer.j2
-        dest: /etc/systemd/system/validator-logrotate.timer
+        dest: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.timer"
         mode: "0644"
       become: true
 
-    - name: Reload systemd to pick up new timer
+    - name: configure - Reload systemd to pick up new timer
       ansible.builtin.systemd:
         daemon_reload: true
       become: true
 
-    - name: Enable and start validator logrotate timer
+    - name: configure - Enable and start validator logrotate timer
       ansible.builtin.systemd:
-        name: validator-logrotate.timer
+        name: "validator-logrotate-{{ validator_service_name }}.timer"
         enabled: true
         state: started
       become: true
   when: solana_cluster == 'localnet'
 
-- name: Configure validator systemd service
+- name: configure - Configure validator systemd service
   block:
-    - name: Create systemd service directory
+    - name: configure - Create systemd service directory
       ansible.builtin.file:
         path: /etc/systemd/system
         state: directory
         mode: "0755"
       become: true
 
-    - name: Create validator systemd service
+    - name: configure - Create validator systemd service
       ansible.builtin.template:
         src: validator.service.j2
         dest: "/etc/systemd/system/{{ validator_service_name }}.service"
         mode: "0644"
       become: true
 
-    - name: Reload systemd daemon
+    - name: configure - Reload systemd daemon
       ansible.builtin.systemd:
         daemon_reload: true
       become: true
 
-    - name: Enable validator service
+    - name: configure - Enable validator service
       ansible.builtin.systemd:
         name: "{{ validator_service_name }}"
         enabled: true
         state: started
       become: true
   rescue:
-    - name: Fail with error message
+    - name: configure - Fail with error message
       ansible.builtin.fail:
         msg: "Failed to configure validator systemd service. Error: {{ ansible_failed_result }}"
 
-- name: Configuration complete
+- name: configure - Configuration complete
   ansible.builtin.debug:
     msg: "Agave validator configuration completed successfully"

--- a/ansible/roles/solana_validator_agave/tasks/host_cleanup.yml
+++ b/ansible/roles/solana_validator_agave/tasks/host_cleanup.yml
@@ -1,0 +1,24 @@
+---
+- name: Stop existing validator service if running
+  ansible.builtin.systemd:
+    name: "{{ validator_service_name }}"
+    state: stopped
+    enabled: false
+  ignore_errors: true
+
+- name: Remove existing validator service file
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ validator_service_name }}.service"
+    state: absent
+  ignore_errors: true
+
+- name: Remove existing validator script
+  ansible.builtin.file:
+    path: "{{ validator_script_path }}"
+    state: absent
+  ignore_errors: true
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true

--- a/ansible/roles/solana_validator_agave/tasks/host_cleanup.yml
+++ b/ansible/roles/solana_validator_agave/tasks/host_cleanup.yml
@@ -1,24 +1,46 @@
 ---
-- name: Stop existing validator service if running
-  ansible.builtin.systemd:
-    name: "{{ validator_service_name }}"
-    state: stopped
-    enabled: false
-  ignore_errors: true
+- name: Clean validator data before start
+  ansible.builtin.shell: |
+    #!/bin/bash
+    set -e
 
-- name: Remove existing validator service file
+    # Clean up the validator data directory
+    echo "Cleaning ledger directory..."
+    rm -rf {{ ledger_path }}/*
+
+    echo "Cleaning accounts directory..."
+    rm -rf {{ accounts_path }}/*
+
+    echo "Cleaning snapshots directory..."
+    rm -rf {{ snapshots_path }}/*
+  delegate_to: "{{ target_host }}"
+
+- name: Ensure ledger directory exists
   ansible.builtin.file:
-    path: "/etc/systemd/system/{{ validator_service_name }}.service"
-    state: absent
-  ignore_errors: true
-
-- name: Remove existing validator script
-  ansible.builtin.file:
-    path: "{{ validator_script_path }}"
-    state: absent
-  ignore_errors: true
-
-- name: Reload systemd daemon
-  ansible.builtin.systemd:
-    daemon_reload: true
+    path: "{{ ledger_path }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
   become: true
+  delegate_to: "{{ target_host }}"
+
+- name: Ensure accounts directory exists
+  ansible.builtin.file:
+    path: "{{ accounts_path }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+  become: true
+  delegate_to: "{{ target_host }}"
+
+- name: Ensure snapshots directory exists
+  ansible.builtin.file:
+    path: "{{ snapshots_path }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+  become: true
+  delegate_to: "{{ target_host }}"

--- a/ansible/roles/solana_validator_agave/tasks/host_cleanup.yml
+++ b/ansible/roles/solana_validator_agave/tasks/host_cleanup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Clean validator data before start
+- name: host_cleanup - Clean validator data before start
   ansible.builtin.shell: |
     #!/bin/bash
     set -e
@@ -15,7 +15,7 @@
     rm -rf {{ snapshots_path }}/*
   delegate_to: "{{ target_host }}"
 
-- name: Ensure ledger directory exists
+- name: host_cleanup - Ensure ledger directory exists
   ansible.builtin.file:
     path: "{{ ledger_path }}"
     state: directory
@@ -25,7 +25,7 @@
   become: true
   delegate_to: "{{ target_host }}"
 
-- name: Ensure accounts directory exists
+- name: host_cleanup - Ensure accounts directory exists
   ansible.builtin.file:
     path: "{{ accounts_path }}"
     state: directory
@@ -35,7 +35,7 @@
   become: true
   delegate_to: "{{ target_host }}"
 
-- name: Ensure snapshots directory exists
+- name: host_cleanup - Ensure snapshots directory exists
   ansible.builtin.file:
     path: "{{ snapshots_path }}"
     state: directory

--- a/ansible/roles/solana_validator_agave/tasks/main.yml
+++ b/ansible/roles/solana_validator_agave/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Precheck parameters
+  import_tasks: precheck.yml
+  tags: [solana_validator_agave, precheck]
+
+- name: Prepare variables needed for the role
+  import_tasks: prepare.yml
+  tags: [solana_validator_agave, prepare]
+
+- name: Cleanup the host from existing validator data
+  import_tasks: host_cleanup.yml
+  when: force_host_cleanup is defined and force_host_cleanup == "true"
+  tags: [solana_validator_agave, cleanup]
+
+- name: Configure and start Agave validator
+  import_tasks: configure.yml
+  tags: [solana_validator_agave, configure]
+
+- name: Verify Agave validator installation
+  import_tasks: verify.yml
+  tags: [solana_validator_agave, verify]
+
+- name: Print Summary
+  import_tasks: summary.yml
+  tags: [solana_validator_agave, summary]

--- a/ansible/roles/solana_validator_agave/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_agave/tasks/precheck.yml
@@ -33,13 +33,6 @@
         msg: "primary-target-identity.json not found in {{ ansible_home_dir }}/.validator-keys/{{ validator_name }}"
       when: not primary_target_identity_file.stat.exists
 
-    # - name: precheck - Get primary target identity pubkey
-    #   ansible.builtin.command: solana-keygen pubkey {{ ansible_home_dir }}/.validator-keys/{{ validator_name }}/primary-target-identity.json
-    #   register: primary_target_pubkey
-    #   delegate_to: localhost
-    #   run_once: true
-    #   when: validator_type == 'primary'
-
     - name: precheck - Check if vote-account.json exists in ansible_keys_dir
       ansible.builtin.stat:
         path: "{{ ansible_home_dir }}/.validator-keys/{{ validator_name }}/vote-account.json"

--- a/ansible/roles/solana_validator_agave/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_agave/tasks/precheck.yml
@@ -1,42 +1,60 @@
 ---
-- name: Check if required variables are defined
+- name: precheck - Ensure the validator_keys_dir is defined and valid
   ansible.builtin.assert:
     that:
-      - validator_name is defined
-      - validator_type is defined
-      - solana_cluster is defined
-    fail_msg: "Required variables validator_name, validator_type, and solana_cluster must be defined"
+      - validator_keys_dir is defined
+      - validator_keys_dir == keys_dir + "/" + validator_name
+    fail_msg: >
+      "Variable 'validator_keys_dir' must be defined."
+    success_msg: "validator_keys_dir is set to {{ validator_keys_dir }}"
 
-- name: Check if validator keys directory exists
-  ansible.builtin.stat:
-    path: "{{ validator_keys_dir }}"
-  register: validator_keys_dir_stat
-
-- name: Assert validator keys directory exists
-  ansible.builtin.assert:
-    that:
-      - validator_keys_dir_stat.stat.exists
-    fail_msg: "Validator keys directory {{ validator_keys_dir }} does not exist"
-
-- name: Check if identity key exists
-  ansible.builtin.stat:
-    path: "{{ validator_keys_dir }}/identity.json"
-  register: identity_key_stat
-
-- name: Assert identity key exists
-  ansible.builtin.assert:
-    that:
-      - identity_key_stat.stat.exists
-    fail_msg: "Identity key {{ validator_keys_dir }}/identity.json does not exist"
-
-- name: Check if vote account pubkey is defined
-  ansible.builtin.assert:
-    that:
-      - vote_account_pubkey is defined
-    fail_msg: "vote_account_pubkey must be defined"
-
-- name: Check if expected genesis hash is defined
+- name: precheck - Check if expected genesis hash is defined
   ansible.builtin.assert:
     that:
       - expected_genesis_hash is defined
     fail_msg: "expected_genesis_hash must be defined"
+
+- name: precheck - Gather facts for localhost
+  ansible.builtin.setup:
+  delegate_to: localhost
+  run_once: true
+
+- name: Check required validator keypairs
+  block:
+    - name: precheck - Check if primary-target-identity.json exists in ansible_keys_dir
+      ansible.builtin.stat:
+        path: "{{ ansible_home_dir }}/.validator-keys/{{ validator_name }}/primary-target-identity.json"
+      register: primary_target_identity_file
+      delegate_to: localhost
+      run_once: true
+
+    - name: precheck - Fail if primary-target-identity.json is missing
+      ansible.builtin.fail:
+        msg: "primary-target-identity.json not found in {{ ansible_home_dir }}/.validator-keys/{{ validator_name }}"
+      when: not primary_target_identity_file.stat.exists
+
+    # - name: precheck - Get primary target identity pubkey
+    #   ansible.builtin.command: solana-keygen pubkey {{ ansible_home_dir }}/.validator-keys/{{ validator_name }}/primary-target-identity.json
+    #   register: primary_target_pubkey
+    #   delegate_to: localhost
+    #   run_once: true
+    #   when: validator_type == 'primary'
+
+    - name: precheck - Check if vote-account.json exists in ansible_keys_dir
+      ansible.builtin.stat:
+        path: "{{ ansible_home_dir }}/.validator-keys/{{ validator_name }}/vote-account.json"
+      register: vote_account_file
+      delegate_to: localhost
+      run_once: true
+
+    - name: precheck - Fail if vote-account.json is missing
+      ansible.builtin.fail:
+        msg: "vote-account.json not found in {{ ansible_home_dir }}/.validator-keys/{{ validator_name }}"
+      when: not vote_account_file.stat.exists
+
+- name: precheck - Get host architecture
+  ansible.builtin.import_tasks: ../../common/tasks/set_host_architecture.yml
+
+# Disk space requirements (experimental)
+- name: precheck - Check minimum disk space
+  ansible.builtin.import_tasks: ../../common/tasks/check_minimum_disk_space.yml

--- a/ansible/roles/solana_validator_agave/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_agave/tasks/precheck.yml
@@ -1,0 +1,42 @@
+---
+- name: Check if required variables are defined
+  ansible.builtin.assert:
+    that:
+      - validator_name is defined
+      - validator_type is defined
+      - solana_cluster is defined
+    fail_msg: "Required variables validator_name, validator_type, and solana_cluster must be defined"
+
+- name: Check if validator keys directory exists
+  ansible.builtin.stat:
+    path: "{{ validator_keys_dir }}"
+  register: validator_keys_dir_stat
+
+- name: Assert validator keys directory exists
+  ansible.builtin.assert:
+    that:
+      - validator_keys_dir_stat.stat.exists
+    fail_msg: "Validator keys directory {{ validator_keys_dir }} does not exist"
+
+- name: Check if identity key exists
+  ansible.builtin.stat:
+    path: "{{ validator_keys_dir }}/identity.json"
+  register: identity_key_stat
+
+- name: Assert identity key exists
+  ansible.builtin.assert:
+    that:
+      - identity_key_stat.stat.exists
+    fail_msg: "Identity key {{ validator_keys_dir }}/identity.json does not exist"
+
+- name: Check if vote account pubkey is defined
+  ansible.builtin.assert:
+    that:
+      - vote_account_pubkey is defined
+    fail_msg: "vote_account_pubkey must be defined"
+
+- name: Check if expected genesis hash is defined
+  ansible.builtin.assert:
+    that:
+      - expected_genesis_hash is defined
+    fail_msg: "expected_genesis_hash must be defined"

--- a/ansible/roles/solana_validator_agave/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_agave/tasks/prepare.yml
@@ -24,25 +24,47 @@
       when: service_status.status.ActiveState == "active"
       become: true
 
-- name: prepare - Remove old validator logrotate config if it exists
-  ansible.builtin.file:
-    path: "/etc/logrotate.d/{{ validator_service_name }}"
-    state: absent
-  become: true
+# Block 1: Remove parameterized logrotate config and systemd units
+- name: prepare - Remove parameterized validator logrotate config and systemd units
+  block:
+    - name: prepare - Remove parameterized validator logrotate config if it exists
+      ansible.builtin.file:
+        path: "/etc/logrotate.d/{{ validator_service_name }}"
+        state: absent
+      become: true
 
-- name: prepare - Remove old validator logrotate systemd service if it exists (localnet only)
-  ansible.builtin.file:
-    path: /etc/systemd/system/validator-logrotate.service
-    state: absent
-  become: true
-  when: solana_cluster == 'localnet'
+    - name: prepare - Remove parameterized validator logrotate systemd service if it exists
+      ansible.builtin.file:
+        path: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.service"
+        state: absent
+      become: true
 
-- name: prepare - Remove old validator logrotate systemd timer if it exists (localnet only)
-  ansible.builtin.file:
-    path: /etc/systemd/system/validator-logrotate.timer
-    state: absent
-  become: true
-  when: solana_cluster == 'localnet'
+    - name: prepare - Remove parameterized validator logrotate systemd timer if it exists
+      ansible.builtin.file:
+        path: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.timer"
+        state: absent
+      become: true
+
+# Block 2: Remove legacy logrotate config and systemd units (old convention)
+- name: prepare - Remove legacy validator logrotate config and systemd units (backward compatibility)
+  block:
+    - name: prepare - Remove legacy validator logrotate config if it exists
+      ansible.builtin.file:
+        path: /etc/logrotate.d/validator.logrotate
+        state: absent
+      become: true
+
+    - name: prepare - Remove legacy validator logrotate systemd service if it exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/validator-logrotate.service
+        state: absent
+      become: true
+
+    - name: prepare - Remove legacy validator logrotate systemd timer if it exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/validator-logrotate.timer
+        state: absent
+      become: true
 
 - name: prepare - Clear logs and key store
   ansible.builtin.shell: |

--- a/ansible/roles/solana_validator_agave/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_agave/tasks/prepare.yml
@@ -1,0 +1,40 @@
+---
+- name: Create logs directory
+  ansible.builtin.file:
+    path: "{{ logs_dir }}"
+    state: directory
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+    mode: '0755'
+
+- name: Create ledger directory
+  ansible.builtin.file:
+    path: "{{ ledger_path }}"
+    state: directory
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+    mode: '0755'
+
+- name: Create accounts directory
+  ansible.builtin.file:
+    path: "{{ accounts_path }}"
+    state: directory
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+    mode: '0755'
+
+- name: Create snapshots directory
+  ansible.builtin.file:
+    path: "{{ snapshots_path }}"
+    state: directory
+    owner: "{{ solana_user }}"
+    group: "{{ solana_user }}"
+    mode: '0755'
+
+- name: Set validator script path
+  ansible.builtin.set_fact:
+    validator_script_path: "{{ validator_scripts_dir }}/{{ validator_name }}-{{ solana_cluster }}.sh"
+
+- name: Set systemd service name
+  ansible.builtin.set_fact:
+    validator_service_name: "{{ validator_name }}-{{ solana_cluster }}"

--- a/ansible/roles/solana_validator_agave/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_agave/tasks/prepare.yml
@@ -1,9 +1,9 @@
 ---
-- name: Determine if we should cleanup the host from existing validator data
+- name: prepare - Determine if we should cleanup the host from existing validator data
   ansible.builtin.set_fact:
     should_cleanup_host_data: "{{ force_host_cleanup | default(false) }}"
 
-- name: Stop validator service
+- name: prepare - Stop validator service
   block:
     - name: prepare - Check if validator service exists and is running
       ansible.builtin.systemd:
@@ -44,7 +44,7 @@
   become: true
   when: solana_cluster == 'localnet'
 
-- name: Clear logs and key store
+- name: prepare - Clear logs and key store
   ansible.builtin.shell: |
     #!/bin/bash
     set -e
@@ -59,7 +59,7 @@
     rm -rf {{ keys_dir }}/*
   delegate_to: "{{ target_host }}"
 
-- name: Ensure logs directory exists
+- name: prepare - Ensure logs directory exists
   ansible.builtin.file:
     path: "{{ logs_dir }}"
     state: directory
@@ -68,7 +68,7 @@
     group: "{{ solana_user }}"
   become: true
 
-- name: Ensure keys directory exists
+- name: prepare - Ensure keys directory exists
   ansible.builtin.file:
     path: "{{ keys_dir }}"
     state: directory
@@ -77,7 +77,7 @@
     group: "{{ solana_user }}"
   become: true
 
-- name: Ensure scripts directory exists
+- name: prepare - Ensure scripts directory exists
   ansible.builtin.file:
     path: "{{ scripts_dir }}"
     state: directory

--- a/ansible/roles/solana_validator_agave/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_agave/tasks/prepare.yml
@@ -1,40 +1,87 @@
 ---
-- name: Create logs directory
+- name: Determine if we should cleanup the host from existing validator data
+  ansible.builtin.set_fact:
+    should_cleanup_host_data: "{{ force_host_cleanup | default(false) }}"
+
+- name: Stop validator service
+  block:
+    - name: prepare - Check if validator service exists and is running
+      ansible.builtin.systemd:
+        name: "{{ validator_service_name }}"
+      register: service_status
+      changed_when: false
+      failed_when: false
+
+    - name: prepare - Stop validator service if running
+      ansible.builtin.systemd:
+        name: "{{ validator_service_name }}"
+        state: stopped
+        enabled: false
+      register: stop_result
+      retries: 3
+      delay: 10
+      until: stop_result is success
+      when: service_status.status.ActiveState == "active"
+      become: true
+
+- name: prepare - Remove old validator logrotate config if it exists
+  ansible.builtin.file:
+    path: "/etc/logrotate.d/{{ validator_service_name }}"
+    state: absent
+  become: true
+
+- name: prepare - Remove old validator logrotate systemd service if it exists (localnet only)
+  ansible.builtin.file:
+    path: /etc/systemd/system/validator-logrotate.service
+    state: absent
+  become: true
+  when: solana_cluster == 'localnet'
+
+- name: prepare - Remove old validator logrotate systemd timer if it exists (localnet only)
+  ansible.builtin.file:
+    path: /etc/systemd/system/validator-logrotate.timer
+    state: absent
+  become: true
+  when: solana_cluster == 'localnet'
+
+- name: Clear logs and key store
+  ansible.builtin.shell: |
+    #!/bin/bash
+    set -e
+
+    echo "Cleaning logs directory..."
+    rm -rf {{ logs_dir }}/*
+
+    echo "Cleaning scripts directory..."
+    rm -rf {{ scripts_dir }}/*
+
+    echo "Cleaning keys directory..."
+    rm -rf {{ keys_dir }}/*
+  delegate_to: "{{ target_host }}"
+
+- name: Ensure logs directory exists
   ansible.builtin.file:
     path: "{{ logs_dir }}"
     state: directory
+    mode: "0755"
     owner: "{{ solana_user }}"
     group: "{{ solana_user }}"
-    mode: '0755'
+  become: true
 
-- name: Create ledger directory
+- name: Ensure keys directory exists
   ansible.builtin.file:
-    path: "{{ ledger_path }}"
+    path: "{{ keys_dir }}"
     state: directory
+    mode: "0755"
     owner: "{{ solana_user }}"
     group: "{{ solana_user }}"
-    mode: '0755'
+  become: true
 
-- name: Create accounts directory
+- name: Ensure scripts directory exists
   ansible.builtin.file:
-    path: "{{ accounts_path }}"
+    path: "{{ scripts_dir }}"
     state: directory
+    mode: "0755"
     owner: "{{ solana_user }}"
     group: "{{ solana_user }}"
-    mode: '0755'
-
-- name: Create snapshots directory
-  ansible.builtin.file:
-    path: "{{ snapshots_path }}"
-    state: directory
-    owner: "{{ solana_user }}"
-    group: "{{ solana_user }}"
-    mode: '0755'
-
-- name: Set validator script path
-  ansible.builtin.set_fact:
-    validator_script_path: "{{ validator_scripts_dir }}/{{ validator_name }}-{{ solana_cluster }}.sh"
-
-- name: Set systemd service name
-  ansible.builtin.set_fact:
-    validator_service_name: "{{ validator_name }}-{{ solana_cluster }}"
+  become: true

--- a/ansible/roles/solana_validator_agave/tasks/summary.yml
+++ b/ansible/roles/solana_validator_agave/tasks/summary.yml
@@ -1,0 +1,33 @@
+---
+- name: Display Agave validator installation summary
+  ansible.builtin.debug:
+    msg: |
+      ========================================
+      Agave Validator Installation Summary
+      ========================================
+
+      Validator Name: {{ validator_name }}
+      Validator Type: {{ validator_type }}
+      Solana Cluster: {{ solana_cluster }}
+      Target Host: {{ target_host }}
+
+      Service Name: {{ validator_service_name }}
+      Service Status: Active
+
+      Directories Created:
+      - Logs: {{ logs_dir }}
+      - Ledger: {{ ledger_path }}
+      - Accounts: {{ accounts_path }}
+      - Snapshots: {{ snapshots_path }}
+
+      Files Created:
+      - Startup Script: {{ validator_script_path }}
+      - Systemd Service: /etc/systemd/system/{{ validator_service_name }}.service
+      - Logrotate Config: /etc/logrotate.d/{{ validator_service_name }}
+
+      Next Steps:
+      1. Monitor validator logs: tail -f {{ logs_dir }}/agave-validator.log
+      2. Check service status: systemctl status {{ validator_service_name }}
+      3. View validator info: solana validators
+
+      ========================================

--- a/ansible/roles/solana_validator_agave/tasks/summary.yml
+++ b/ansible/roles/solana_validator_agave/tasks/summary.yml
@@ -10,19 +10,8 @@
       Validator Type: {{ validator_type }}
       Solana Cluster: {{ solana_cluster }}
       Target Host: {{ target_host }}
-
       Service Name: {{ validator_service_name }}
       Service Status: Active
-
-      Directories Created:
-      - Logs: {{ logs_dir }}
-      - Ledger: {{ ledger_path }}
-      - Accounts: {{ accounts_path }}
-      - Snapshots: {{ snapshots_path }}
-
-      Files Created:
-      - Startup Script: {{ validator_script_path }}
-      - Systemd Service: /etc/systemd/system/{{ validator_service_name }}.service
-      - Logrotate Config: /etc/logrotate.d/{{ validator_service_name }}
+      Validator Logs: {{ logs_dir }}
 
       ========================================

--- a/ansible/roles/solana_validator_agave/tasks/summary.yml
+++ b/ansible/roles/solana_validator_agave/tasks/summary.yml
@@ -1,5 +1,5 @@
 ---
-- name: Display Agave validator installation summary
+- name: summary - Display Agave validator installation summary
   ansible.builtin.debug:
     msg: |
       ========================================
@@ -24,10 +24,5 @@
       - Startup Script: {{ validator_script_path }}
       - Systemd Service: /etc/systemd/system/{{ validator_service_name }}.service
       - Logrotate Config: /etc/logrotate.d/{{ validator_service_name }}
-
-      Next Steps:
-      1. Monitor validator logs: tail -f {{ logs_dir }}/agave-validator.log
-      2. Check service status: systemctl status {{ validator_service_name }}
-      3. View validator info: solana validators
 
       ========================================

--- a/ansible/roles/solana_validator_agave/tasks/verify.yml
+++ b/ansible/roles/solana_validator_agave/tasks/verify.yml
@@ -1,37 +1,73 @@
----
-- name: Wait for validator service to start
-  ansible.builtin.wait_for:
-    timeout: 30
-
-- name: Check validator service status
-  ansible.builtin.systemd:
-    name: "{{ validator_service_name }}"
-  register: validator_service_status
-
-- name: Assert validator service is active
-  ansible.builtin.assert:
-    that:
-      - validator_service_status.status.ActiveState == "active"
-    fail_msg: "Validator service {{ validator_service_name }} is not active"
-
-- name: Check if validator log file exists
+# Check if Agave binary exists
+- name: Check if Agave binary exists
   ansible.builtin.stat:
-    path: "{{ logs_dir }}/agave-validator.log"
-  register: validator_log_stat
+    path: "{{ solana_install_dir }}"
+  register: agave_binary
 
-- name: Assert validator log file exists
-  ansible.builtin.assert:
-    that:
-      - validator_log_stat.stat.exists
-    fail_msg: "Validator log file {{ logs_dir }}/agave-validator.log does not exist"
+- name: Fail if Agave binary is missing
+  ansible.builtin.fail:
+    msg: "Agave binary not found at {{ solana_install_dir }}!"
+  when: not agave_binary.stat.exists
 
-- name: Check validator process is running
-  ansible.builtin.shell: "pgrep -f 'agave-validator'"
-  register: validator_process_check
-  ignore_errors: true
+# Print validator service status
+- name: Print validator service status
+  ansible.builtin.debug:
+    var: validator_service_status
 
-- name: Assert validator process is running
-  ansible.builtin.assert:
-    that:
-      - validator_process_check.rc == 0
-    fail_msg: "Agave validator process is not running"
+# Get last 50 lines of validator logs
+- name: Get last 50 lines of validator logs
+  ansible.builtin.shell: journalctl -u {{ validator_service_name }} --no-pager | tail -n 50
+  register: validator_logs
+  changed_when: false
+
+- name: Print last 50 lines of validator logs
+  ansible.builtin.debug:
+    var: validator_logs.stdout_lines
+
+# Check validator process status
+- name: Check validator process status
+  ansible.builtin.shell: ps aux | grep "agave-validator" | grep -v grep
+  register: validator_process
+  changed_when: false
+
+- name: Print validator process status
+  ansible.builtin.debug:
+    var: validator_process.stdout_lines
+
+# Check validator service file
+- name: Check validator service file
+  ansible.builtin.shell: cat /etc/systemd/system/{{ validator_service_name }}.service
+  register: validator_service_file
+  changed_when: false
+
+- name: Print validator service file
+  ansible.builtin.debug:
+    var: validator_service_file.stdout_lines
+
+# Check validator startup script
+- name: Check validator startup script
+  ansible.builtin.shell: cat {{ scripts_dir }}/run-{{ validator_name }}.sh
+  register: validator_startup_script
+  changed_when: false
+
+- name: Print validator startup script
+  ansible.builtin.debug:
+    var: validator_startup_script.stdout_lines
+
+# Summary - Agave validator verification complete
+- name: Summary - Agave validator verification complete
+  ansible.builtin.debug:
+    msg: |
+      Agave validator verification complete. Check service status and logs above for troubleshooting.
+
+      Service Status Summary:
+      - Binary exists: {{ agave_binary.stat.exists }}
+      - Service active: {{ validator_service_status.status.ActiveState }}
+      - Service enabled: {{ validator_service_status.status.UnitFileState }}
+      - Process running: {{ validator_process.stdout_lines | length > 0 }}
+
+      If the validator is not running properly, check:
+      1. Service status and logs above
+      2. Validator startup script for correct configuration
+      3. Systemd service file for proper setup
+      4. Port availability and firewall settings

--- a/ansible/roles/solana_validator_agave/tasks/verify.yml
+++ b/ansible/roles/solana_validator_agave/tasks/verify.yml
@@ -1,0 +1,37 @@
+---
+- name: Wait for validator service to start
+  ansible.builtin.wait_for:
+    timeout: 30
+
+- name: Check validator service status
+  ansible.builtin.systemd:
+    name: "{{ validator_service_name }}"
+  register: validator_service_status
+
+- name: Assert validator service is active
+  ansible.builtin.assert:
+    that:
+      - validator_service_status.status.ActiveState == "active"
+    fail_msg: "Validator service {{ validator_service_name }} is not active"
+
+- name: Check if validator log file exists
+  ansible.builtin.stat:
+    path: "{{ logs_dir }}/agave-validator.log"
+  register: validator_log_stat
+
+- name: Assert validator log file exists
+  ansible.builtin.assert:
+    that:
+      - validator_log_stat.stat.exists
+    fail_msg: "Validator log file {{ logs_dir }}/agave-validator.log does not exist"
+
+- name: Check validator process is running
+  ansible.builtin.shell: "pgrep -f 'agave-validator'"
+  register: validator_process_check
+  ignore_errors: true
+
+- name: Assert validator process is running
+  ansible.builtin.assert:
+    that:
+      - validator_process_check.rc == 0
+    fail_msg: "Agave validator process is not running"

--- a/ansible/roles/solana_validator_agave/tasks/verify.yml
+++ b/ansible/roles/solana_validator_agave/tasks/verify.yml
@@ -58,15 +58,3 @@
   ansible.builtin.debug:
     msg: |
       Agave validator verification complete. Check service status and logs above for troubleshooting.
-
-      Service Status Summary:
-      - Binary exists: {{ agave_binary.stat.exists }}
-      - Service active: {{ validator_service_status.status.ActiveState }}
-      - Service enabled: {{ validator_service_status.status.UnitFileState }}
-      - Process running: {{ validator_process.stdout_lines | length > 0 }}
-
-      If the validator is not running properly, check:
-      1. Service status and logs above
-      2. Validator startup script for correct configuration
-      3. Systemd service file for proper setup
-      4. Port availability and firewall settings

--- a/ansible/roles/solana_validator_agave/tasks/verify.yml
+++ b/ansible/roles/solana_validator_agave/tasks/verify.yml
@@ -1,61 +1,60 @@
-# Check if Agave binary exists
-- name: Check if Agave binary exists
+- name: verify - Check if Agave binary exists
   ansible.builtin.stat:
     path: "{{ solana_install_dir }}"
   register: agave_binary
 
-- name: Fail if Agave binary is missing
+- name: verify - Fail if Agave binary is missing
   ansible.builtin.fail:
     msg: "Agave binary not found at {{ solana_install_dir }}!"
   when: not agave_binary.stat.exists
 
-# Print validator service status
-- name: Print validator service status
+- name: verify - Get validator systemd service status
+  ansible.builtin.systemd:
+    name: "{{ validator_service_name }}"
+  register: validator_service_status
+  changed_when: false
+
+- name: verify - Print validator service status
   ansible.builtin.debug:
     var: validator_service_status
 
-# Get last 50 lines of validator logs
-- name: Get last 50 lines of validator logs
+- name: verify - Get last 50 lines of validator logs
   ansible.builtin.shell: journalctl -u {{ validator_service_name }} --no-pager | tail -n 50
   register: validator_logs
   changed_when: false
 
-- name: Print last 50 lines of validator logs
+- name: verify - Print last 50 lines of validator logs
   ansible.builtin.debug:
     var: validator_logs.stdout_lines
 
-# Check validator process status
-- name: Check validator process status
+- name: verify - Check validator process status
   ansible.builtin.shell: ps aux | grep "agave-validator" | grep -v grep
   register: validator_process
   changed_when: false
 
-- name: Print validator process status
+- name: verify - Print validator process status
   ansible.builtin.debug:
     var: validator_process.stdout_lines
 
-# Check validator service file
-- name: Check validator service file
+- name: verify - Check validator service file
   ansible.builtin.shell: cat /etc/systemd/system/{{ validator_service_name }}.service
   register: validator_service_file
   changed_when: false
 
-- name: Print validator service file
+- name: verify - Print validator service file
   ansible.builtin.debug:
     var: validator_service_file.stdout_lines
 
-# Check validator startup script
-- name: Check validator startup script
+- name: verify - Check validator startup script
   ansible.builtin.shell: cat {{ scripts_dir }}/run-{{ validator_name }}.sh
   register: validator_startup_script
   changed_when: false
 
-- name: Print validator startup script
+- name: verify - Print validator startup script
   ansible.builtin.debug:
     var: validator_startup_script.stdout_lines
 
-# Summary - Agave validator verification complete
-- name: Summary - Agave validator verification complete
+- name: verify - Summary - Agave validator verification complete
   ansible.builtin.debug:
     msg: |
       Agave validator verification complete. Check service status and logs above for troubleshooting.

--- a/ansible/roles/solana_validator_agave/templates/validator-logrotate.service.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator-logrotate.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Logrotate for {{ validator_service_name }}
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate /etc/logrotate.d/{{ validator_service_name }}

--- a/ansible/roles/solana_validator_agave/templates/validator-logrotate.service.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator-logrotate.service.j2
@@ -4,4 +4,4 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/logrotate /etc/logrotate.d/{{ validator_service_name }}
+ExecStart=/usr/sbin/logrotate -f /etc/logrotate.d/{{ validator_service_name }}

--- a/ansible/roles/solana_validator_agave/templates/validator-logrotate.timer.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator-logrotate.timer.j2
@@ -1,10 +1,9 @@
-
 [Unit]
-Description=Run logrotate for {{ validator_service_name }}
+Description=Run logrotate for {{ validator_service_name }} every hour
 Requires=validator-logrotate-{{ validator_service_name }}.service
 
 [Timer]
-OnCalendar=daily
+OnCalendar=hourly
 Persistent=true
 
 [Install]

--- a/ansible/roles/solana_validator_agave/templates/validator-logrotate.timer.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator-logrotate.timer.j2
@@ -1,9 +1,10 @@
+
 [Unit]
-Description=Run logrotate for {{ validator_service_name }} {{ logrotate_schedule }}
-Requires={{ validator_service_name }}-logrotate.service
+Description=Run logrotate for {{ validator_service_name }}
+Requires=validator-logrotate-{{ validator_service_name }}.service
 
 [Timer]
-OnCalendar={{ logrotate_schedule }}
+OnCalendar=daily
 Persistent=true
 
 [Install]

--- a/ansible/roles/solana_validator_agave/templates/validator-logrotate.timer.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator-logrotate.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run logrotate for {{ validator_service_name }} {{ logrotate_schedule }}
+Requires={{ validator_service_name }}-logrotate.service
+
+[Timer]
+OnCalendar={{ logrotate_schedule }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/solana_validator_agave/templates/validator.logrotate.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.logrotate.j2
@@ -9,6 +9,6 @@
     compress
     missingok
     postrotate
-        systemctl kill -s USR1 {{ validator_service_name }}
+        systemctl kill -s USR1 {{ validator_service_name }}.service
     endscript
 }

--- a/ansible/roles/solana_validator_agave/templates/validator.logrotate.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.logrotate.j2
@@ -1,0 +1,13 @@
+{{ logs_dir }}/agave-validator.log {
+    daily
+    rotate {{ logrotate_rotate_count }}
+    size {{ logrotate_max_size }}
+    missingok
+    notifempty
+    compress
+    delaycompress
+    create 644 {{ solana_user }} {{ solana_user }}
+    postrotate
+        systemctl reload {{ validator_service_name }}
+    endscript
+}

--- a/ansible/roles/solana_validator_agave/templates/validator.logrotate.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.logrotate.j2
@@ -1,13 +1,14 @@
 {{ logs_dir }}/agave-validator.log {
-    daily
     rotate {{ logrotate_rotate_count }}
     size {{ logrotate_max_size }}
-    missingok
-    notifempty
+    {% if solana_cluster == 'localnet' %}
+    size {{ logrotate_max_size_localnet }}
+    {% else %}
+    size {{ logrotate_max_size }}
+    {% endif %}
     compress
-    delaycompress
-    create 644 {{ solana_user }} {{ solana_user }}
+    missingok
     postrotate
-        systemctl reload {{ validator_service_name }}
+        systemctl kill -s USR1 {{ validator_service_name }}
     endscript
 }

--- a/ansible/roles/solana_validator_agave/templates/validator.service.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Solana {{ validator_name }} {{ solana_cluster }} Agave validator
+After=network.target syslog.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User={{ solana_user }}
+LimitNOFILE=1000000
+LogRateLimitIntervalSec=0
+ExecStart={{ validator_script_path }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/solana_validator_agave/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.startup.j2
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+PATH="/bin:/usr/bin:{{ solana_install_dir }}"
+{% if solana_metrics_url is defined and solana_metrics_url != None and solana_metrics_url != '' %}
+export SOLANA_METRICS_CONFIG="host={{ solana_metrics_url }}"
+{% endif %}
+exec agave-validator \
+--identity {{ validator_keys_dir }}/identity.json \
+--vote-account {{ vote_account_pubkey }} \
+--authorized-voter {{ validator_keys_dir }}/primary-target-identity.json \
+{% for known_validator in known_validators %}
+--known-validator {{ known_validator }} \
+{% endfor %}
+{% if only_known_rpc is defined and only_known_rpc %}
+--only-known-rpc \
+{% endif %}
+--ledger {{ ledger_path }} \
+--accounts {{ accounts_path }} \
+--snapshots {{ snapshots_path }} \
+--snapshot-interval-slots {{ snapshot_interval_slots }} \
+--minimal-snapshot-download-speed {{ minimal_snapshot_download_speed }} \
+--private-rpc \
+--rpc-port {{ solana_rpc_port }} \
+--dynamic-port-range {{ open_solana_ports_start }}-{{ open_solana_ports_end }} \
+--gossip-port {{ gossip_port }} \
+{% for entrypoint in solana_gossip_entrypoints %}
+--entrypoint {{ entrypoint }} \
+{% endfor %}
+--expected-genesis-hash {{ expected_genesis_hash }} \
+--wal-recovery-mode skip_any_corrupted_record \
+--limit-ledger-size {{ limit_ledger_size }} \
+--block-verification-method unified-scheduler \
+{% if solana_cluster != "localnet" %}
+{% if poh_pinned_cpu_core_enabled is defined and poh_pinned_cpu_core_enabled and poh_pinned_cpu_core is defined %}
+--experimental-poh-pinned-cpu-core {{ poh_pinned_cpu_core }} \
+{% endif %}
+--disable-accounts-disk-index \
+{% endif %}
+{% if solana_cluster == "localnet" %}
+--no-os-network-limits-test \
+--allow-private-addr \
+{% endif %}
+{% if extra_params is defined %}
+{% for extra_var in extra_params %}
+{{ extra_var }} \
+{% endfor %}
+{% endif %}
+--log {{ logs_dir }}/agave-validator.log

--- a/ansible/roles/solana_validator_agave/vars/main.yml
+++ b/ansible/roles/solana_validator_agave/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-# Other variables are expected as input when calling this role 
+# Other variables are expected as input when calling this role
 # and checked during the role's precheck task

--- a/ansible/roles/solana_validator_agave/vars/main.yml
+++ b/ansible/roles/solana_validator_agave/vars/main.yml
@@ -1,3 +1,0 @@
----
-# Other variables are expected as input when calling this role
-# and checked during the role's precheck task

--- a/ansible/roles/solana_validator_jito/tasks/jito_client/configure/config_logrotate.yml
+++ b/ansible/roles/solana_validator_jito/tasks/jito_client/configure/config_logrotate.yml
@@ -4,12 +4,12 @@
     - name: Create logrotate configuration
       ansible.builtin.template:
         src: validator.logrotate.j2
-        dest: /etc/logrotate.d/validator.logrotate
+        dest: "/etc/logrotate.d/{{ validator_service_name }}"
         mode: "0644"
       become: true
 
     - name: Verify logrotate configuration
-      ansible.builtin.command: logrotate -d /etc/logrotate.d/validator.logrotate
+      ansible.builtin.command: logrotate -d /etc/logrotate.d/{{ validator_service_name }}
       register: logrotate_check
       changed_when: false
       failed_when: false
@@ -25,14 +25,14 @@
     - name: Deploy validator logrotate systemd service
       ansible.builtin.template:
         src: validator-logrotate.service.j2
-        dest: /etc/systemd/system/validator-logrotate.service
+        dest: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.service"
         mode: "0644"
       become: true
 
     - name: Deploy validator logrotate systemd timer
       ansible.builtin.template:
         src: validator-logrotate.timer.j2
-        dest: /etc/systemd/system/validator-logrotate.timer
+        dest: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.timer"
         mode: "0644"
       become: true
 
@@ -43,7 +43,7 @@
 
     - name: Enable and start validator logrotate timer
       ansible.builtin.systemd:
-        name: validator-logrotate.timer
+        name: "validator-logrotate-{{ validator_service_name }}.timer"
         enabled: true
         state: started
       become: true

--- a/ansible/roles/solana_validator_jito/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_jito/tasks/precheck.yml
@@ -100,44 +100,5 @@
   ansible.builtin.import_tasks: ../../common/tasks/set_host_architecture.yml
 
 # Disk space requirements (experimental)
-- name: Get initial disk space
-  ansible.builtin.shell: |
-    df -h "{{ solana_user_dir }}" | awk 'NR==2 {print $4}'
-  register: initial_space
-  changed_when: false
-
-- name: Print initial available space
-  ansible.builtin.debug:
-    msg: "Initial available space in /home/sol: {{ initial_space.stdout }}"
-
-- name: Set minimum required space (experimental)
-  ansible.builtin.set_fact:
-    min_required_space: "14G"  # This is an initial estimate, can be adjusted based on experience
-
-- name: Convert space to bytes for comparison
-  ansible.builtin.set_fact:
-    initial_space_bytes: >-
-      {% set size = initial_space.stdout | regex_replace('^([0-9.]+)\\s*([KMG])$', '\\1') | float %}
-      {% set unit = initial_space.stdout | regex_replace('^[0-9.]+\\s*([KMG])$', '\\1') %}
-      {% if unit == 'K' %}
-        {{ (size * 1024) | int }}
-      {% elif unit == 'M' %}
-        {{ (size * 1024 * 1024) | int }}
-      {% elif unit == 'G' %}
-        {{ (size * 1024 * 1024 * 1024) | int }}
-      {% endif %}
-    min_required_bytes: >-
-      {% set size = min_required_space | regex_replace('^([0-9.]+)\\s*([KMG])$', '\\1') | float %}
-      {% set unit = min_required_space | regex_replace('^[0-9.]+\\s*([KMG])$', '\\1') %}
-      {% if unit == 'K' %}
-        {{ (size * 1024) | int }}
-      {% elif unit == 'M' %}
-        {{ (size * 1024 * 1024) | int }}
-      {% elif unit == 'G' %}
-        {{ (size * 1024 * 1024 * 1024) | int }}
-      {% endif %}
-
-- name: Check if available space is sufficient
-  ansible.builtin.fail:
-    msg: "Insufficient disk space. Available: {{ initial_space.stdout }}, Minimum required: {{ min_required_space }}"
-  when: initial_space_bytes | int < min_required_bytes | int
+- name: Check minimum disk space
+  ansible.builtin.import_tasks: ../../common/tasks/check_minimum_disk_space.yml

--- a/ansible/roles/solana_validator_jito/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_jito/tasks/prepare.yml
@@ -32,28 +32,47 @@
 - name: Stop and remove relayer service if exists
   import_tasks: jito_relayer_cohosted/stop_service.yml
 
-- name: Remove old validator logrotate config if it exists
-  ansible.builtin.file:
-    path: /etc/logrotate.d/validator.logrotate
-    state: absent
-  become: true
-  delegate_to: "{{ target_host }}"
+# Block 1: Remove parameterized logrotate config and systemd units
+- name: Remove parameterized validator logrotate config and systemd units
+  block:
+    - name: Remove parameterized validator logrotate config if it exists
+      ansible.builtin.file:
+        path: "/etc/logrotate.d/{{ validator_service_name }}"
+        state: absent
+      become: true
 
-- name: Remove old validator logrotate systemd service if it exists (localnet only)
-  ansible.builtin.file:
-    path: /etc/systemd/system/validator-logrotate.service
-    state: absent
-  become: true
-  when: solana_cluster == 'localnet'
-  delegate_to: "{{ target_host }}"
+    - name: Remove parameterized validator logrotate systemd service if it exists
+      ansible.builtin.file:
+        path: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.service"
+        state: absent
+      become: true
 
-- name: Remove old validator logrotate systemd timer if it exists (localnet only)
-  ansible.builtin.file:
-    path: /etc/systemd/system/validator-logrotate.timer
-    state: absent
-  become: true
-  when: solana_cluster == 'localnet'
-  delegate_to: "{{ target_host }}"
+    - name: Remove parameterized validator logrotate systemd timer if it exists
+      ansible.builtin.file:
+        path: "/etc/systemd/system/validator-logrotate-{{ validator_service_name }}.timer"
+        state: absent
+      become: true
+
+# Block 2: Remove legacy logrotate config and systemd units (old convention)
+- name: Remove legacy validator logrotate config and systemd units (backward compatibility)
+  block:
+    - name: Remove legacy validator logrotate config if it exists
+      ansible.builtin.file:
+        path: /etc/logrotate.d/validator.logrotate
+        state: absent
+      become: true
+
+    - name: Remove legacy validator logrotate systemd service if it exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/validator-logrotate.service
+        state: absent
+      become: true
+
+    - name: Remove legacy validator logrotate systemd timer if it exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/validator-logrotate.timer
+        state: absent
+      become: true
 
 - name: Clear logs and key store
   ansible.builtin.shell: |

--- a/ansible/roles/solana_validator_jito/templates/validator-logrotate.service.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator-logrotate.service.j2
@@ -1,6 +1,6 @@
 [Unit]
-Description=Logrotate for validator logs
+Description=Logrotate for {{ validator_service_name }}
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/logrotate -f /etc/logrotate.d/validator.logrotate
+ExecStart=/usr/sbin/logrotate -f /etc/logrotate.d/{{ validator_service_name }}

--- a/ansible/roles/solana_validator_jito/templates/validator-logrotate.timer.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator-logrotate.timer.j2
@@ -1,5 +1,6 @@
 [Unit]
-Description=Run validator logrotate every hour
+Description=Run logrotate for {{ validator_service_name }} every hour
+Requires=validator-logrotate-{{ validator_service_name }}.service
 
 [Timer]
 OnCalendar=hourly

--- a/ansible/roles/solana_validator_jito/templates/validator.logrotate.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator.logrotate.j2
@@ -1,13 +1,14 @@
 {{ logs_dir }}/agave-validator.log {
-  rotate 1
-  {% if solana_cluster == 'localnet' %}
-  size 100M
-  {% else %}
-  size 1G
-  {% endif %}
-  compress
-  missingok
-  postrotate
-    systemctl kill -s USR1 sol.service
-  endscript
+    rotate {{ logrotate_rotate_count }}
+    size {{ logrotate_max_size }}
+    {% if solana_cluster == 'localnet' %}
+    size {{ logrotate_max_size_localnet }}
+    {% else %}
+    size {{ logrotate_max_size }}
+    {% endif %}
+    compress
+    missingok
+    postrotate
+        systemctl kill -s USR1 {{ validator_service_name }}.service
+    endscript
 }


### PR DESCRIPTION
This pull request introduces a new Ansible role and supporting playbook to automate the setup and configuration of an Agave Solana validator. It includes robust parameter validation, system preparation and log rotation improvements. The changes are organized to have better maintainability.

- Added a new playbook (`pb_setup_validator_agave.yml`) and a dedicated role (`solana_validator_agave`) to automate the setup of an Agave Solana validator
- Refactored disk space check for rehusability
- Refactored logrotate setup and cleanup
- Role Metadata and Dependency Updates
- Leverage keyset installation using shared task `install_validator_keyset.yml`

To test the playbook against `host-bravo` on the localnet cluster, run:

```bash
ansible-playbook playbooks/pb_setup_validator_agave.yml \
  -i solana_localnet.yml \
  --limit host-bravo \
  -e "target_host=host-bravo" \
  -e "validator_name=penny" \
  -e "validator_type=primary" \
  -e "agave_version=2.3.6" \
  -e "solana_cluster=localnet" \
  -e "build_from_source=false" \
  -e "use_official_repo=true"
  ```
  
  > NOTE: While the goal of this PR is to add the Agave validator setup role and playbook, as part of the logrotate setup, parametrization and pre-setup cleanup improvements, I have also updated the logrotate related files on the `solana_validator_jito` role to have feature symetry.