### PR TITLE
Update ownership and permissions for validator files

### DIFF
--- a/ansible/roles/server_initial_setup/vars/main.yml
+++ b/ansible/roles/server_initial_setup/vars/main.yml
@@ -52,9 +52,9 @@ validator_directory_name: "validator"
 validator_directory:
   name: "{{ validator_directory_name }}"
   path: "/opt/{{ validator_directory_name }}"
-  owner: "{{ sol_owner }}"
+  owner: "root"
   group: "{{ validator_group }}"
-  mode: '2575'
+  mode: '2775'
   scripts_subdir: "scripts"
 
 # Mount directories list
@@ -90,6 +90,6 @@ filesystem_formats:
 health_check:
   script_name: "health_check.sh"
   dest_path: "{{ validator_directory.path }}/{{ validator_directory.scripts_subdir }}/{{ health_check.script_name }}"
-  owner: "{{ sol_owner }}"
+  owner: "root"
   group: "{{ validator_group }}"
-  mode: "0575"
+  mode: "0775"


### PR DESCRIPTION
# Update ownership and permissions for validator directory

## 📝 Summary

This pull request updates ownership and permissions settings for the validator directory and its health check script in the `server_initial_setup` role. The changes make `root` the owner and adjust the directory and script permissions to be more permissive.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🚀 Performance improvement
- [x] ♻️ Code refactoring (no functional changes)

## 🔍 Scope & Complexity

**Please keep PRs focused and small for faster reviews.**

- [x] This PR changes **fewer than 400 lines** of code (excluding generated files)
- [x] This PR addresses **only one logical change** or feature
- [x] This PR can be **reviewed in under 30 minutes**
- [x] This PR does **not mix multiple types of changes** (e.g., refactoring + new features)

If any of the above are unchecked, consider breaking this PR into smaller, focused changes.

## 📋 Changes Made

Detailed list of changes:

- Changed the `owner` of `validator_directory` from `{{ sol_owner }}` to `root` and updated the `mode` from `'2575'` to `'2775'` in `ansible/roles/server_initial_setup/vars/main.yml`
- Changed the `owner` of the health check script from `{{ sol_owner }}` to `root` and updated the `mode` from `"0575"` to `"0775"` in `ansible/roles/server_initial_setup/vars/main.yml`

## 🧪 Testing

- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Manual testing completed
- [ ] Existing functionality verified unchanged
- [ ] Documentation updated (if applicable)

### Test Details

# Requirements: CSV Files for Users

For testing, you will need two CSV files:

- A CSV containing the users and their roles

These CSVs should be placed in your **local computer**:

  ~/new-metal-box/

### Example: Users and Roles CSV (`~/new-metal-box/iam_setup_dev.csv`)

> **Testing Tip:** For testing purposes only, it is recommended to use the same public key for all users in the CSV. This is necessary because you will run playbooks with both the sysadmin role and the validator operator role, and using the same key allows you to access the server as each user to verify their roles and permissions work as expected. Use a public key you have access to.

## 1. Create Users

Run the following command to create the users defined in the `iam_setup.csv` file on the target host:

```bash
ansible-playbook playbooks/pb_setup_server_users.yml \
  -i solana_localnet.yml \
  -e "target_host=host-charlie" \
  -e "ansible_user=ubuntu" \
  -e "csv_file=iam_setup_dev.csv"
```

## 2. Establish First SSH Connection and Set Password

Once the users have been configured, you must establish a first SSH connection to the target host (e.g., host-charlie) using a user with the sysadmin role. This will add the target host's SSH fingerprint to the Ansible control node and verify access:

```bash
ssh alice@172.25.0.13
```

To generate the initial password, you can use the password self-service portal. More information is available at:

https://docs.hayek.fi/dev-public-goods/validator-operations/host-infrastructure/user-access#password-self-service
ll /opt/validator/

After completing these steps, you can proceed to run the playbook that creates the directory where all Solana software and assets will reside.

## 3. Create the Validator Directory

To create the required directory structure for the validator, run:

```bash
ansible-playbook playbooks/pb_setup_metal_box.yml \
  -i solana_localnet.yml \
  -e "target_host=host-charlie" \
  -e "ansible_user=alice" \
  --tags validator-dir \
  -K
```

- **--tags validator-dir**: Runs only the tasks related to validator directory creation.
- **-K**: Prompts for the sudo password if needed.

Verify the created structure:

```bash
ll /opt/validator/
```

Example output:
<img width="667" height="77" alt="Screenshot 2025-10-17 at 11 35 18 AM" src="https://github.com/user-attachments/assets/f78d18ac-263c-4e0c-bcfd-3d4bd12ea02c" />


## 📚 Documentation

- [ ] Updated relevant documentation
- [ ] Added/updated comments for complex logic
- [ ] README updated (if applicable)
- [ ] No documentation changes needed

## 🔗 Related Issues

Closes #[issue_number]

## 📝 Review Notes

Any specific areas you'd like reviewers to focus on or context they should know:


---

## For Reviewers

**Estimated review time:** ⏱️ [30 minutes]

**Focus areas:**
- [ ] Logic correctness
- [x] Security implications
- [x] Performance impact
- [ ] Documentation completeness