### PR TITLE
Renamed Validator Variable validator_key_store

### DIFF
--- a/ansible/group_vars/solana.yml
+++ b/ansible/group_vars/solana.yml
@@ -46,7 +46,7 @@ jito_forked_repo: https://github.com/team-supersafe/forked-jito-solana
 validator_root_dir: "/opt/validator"
 validator_scripts_dir: "{{ validator_root_dir }}/scripts"
 validator_logs_dir: "{{ validator_root_dir }}/logs"
-validator_key_store: "{{ validator_root_dir }}/keys"
+validator_keys_dir: "{{ validator_root_dir }}/keys"
 validator_operators_group: "validator_operators"
 
 # directory modes

--- a/ansible/playbooks/pb_hot_swap_validator_hosts_v2.yml
+++ b/ansible/playbooks/pb_hot_swap_validator_hosts_v2.yml
@@ -39,7 +39,7 @@
 
     - name: Check if source host keys directory exists
       ansible.builtin.stat:
-        path: "{{ validator_key_store }}"
+        path: "{{ validator_keys_dir }}"
       register: source_keys_dir_stat
       delegate_to: "{{ source_host }}"
       become: true
@@ -47,7 +47,7 @@
 
     - name: Check if destination host keys directory exists
       ansible.builtin.stat:
-        path: "{{ validator_key_store }}"
+        path: "{{ validator_keys_dir }}"
       register: destination_keys_dir_stat
       delegate_to: "{{ destination_host }}"
       become: true
@@ -56,7 +56,7 @@
     - name: Validate source host keys directory exists
       ansible.builtin.fail:
         msg: >
-          Source host '{{ source_host }}' does not have a validator keys directory at '{{ validator_key_store }}'.
+          Source host '{{ source_host }}' does not have a validator keys directory at '{{ validator_keys_dir }}'.
           This indicates no validator is installed on this host.
           Please ensure a validator is properly installed before attempting a hot swap.
       when: not source_keys_dir_stat.stat.exists
@@ -65,7 +65,7 @@
     - name: Validate destination host keys directory exists
       ansible.builtin.fail:
         msg: >
-          Destination host '{{ destination_host }}' does not have a validator keys directory at '{{ validator_key_store }}'.
+          Destination host '{{ destination_host }}' does not have a validator keys directory at '{{ validator_keys_dir }}'.
           This indicates no validator is installed on this host.
           Please ensure a validator is properly installed before attempting a hot swap.
       when: not destination_keys_dir_stat.stat.exists
@@ -73,7 +73,7 @@
 
     - name: Find validator name on source host
       ansible.builtin.find:
-        paths: "{{ validator_key_store }}"
+        paths: "{{ validator_keys_dir }}"
         file_type: directory
       register: source_keys
       delegate_to: "{{ source_host }}"
@@ -82,7 +82,7 @@
 
     - name: Find validator name on destination host
       ansible.builtin.find:
-        paths: "{{ validator_key_store }}"
+        paths: "{{ validator_keys_dir }}"
         file_type: directory
       register: destination_keys
       delegate_to: "{{ destination_host }}"
@@ -92,7 +92,7 @@
     - name: Validate source host has validator subdirectories
       ansible.builtin.fail:
         msg: >
-          VALIDATION FAILED: Source host '{{ source_host }}' keys directory '{{ validator_key_store }}' exists but contains no validator subdirectories.
+          VALIDATION FAILED: Source host '{{ source_host }}' keys directory '{{ validator_keys_dir }}' exists but contains no validator subdirectories.
           This indicates the validator installation is incomplete or corrupted.
           Please ensure a validator is properly installed on '{{ source_host }}' before attempting a hot swap.
       when: source_keys.files | length == 0
@@ -101,7 +101,7 @@
     - name: Validate destination host has validator subdirectories
       ansible.builtin.fail:
         msg: >
-          VALIDATION FAILED: Destination host '{{ destination_host }}' keys directory '{{ validator_key_store }}' exists but contains no validator subdirectories.
+          VALIDATION FAILED: Destination host '{{ destination_host }}' keys directory '{{ validator_keys_dir }}' exists but contains no validator subdirectories.
           This indicates the validator installation is incomplete or corrupted.
           Please ensure a validator is properly installed on '{{ destination_host }}' before attempting a hot swap.
       when: destination_keys.files | length == 0

--- a/ansible/roles/solana_swap_validator_hosts/tasks/precheck.yml
+++ b/ansible/roles/solana_swap_validator_hosts/tasks/precheck.yml
@@ -14,15 +14,15 @@
     - name: precheck - Get stats of source validator directory
       ansible.builtin.stat:
         path: "{{ source_host_keys_dir }}"
-      register: source_validator_keys_dir
+      register: source_keys_dir_stat
       when: inventory_hostname == source_host
 
     - name: precheck - Set source directory validation fact
       ansible.builtin.set_fact:
         source_dir_valid: >-
           {{
-            source_validator_keys_dir.stat.isdir is defined and
-            source_validator_keys_dir.stat.isdir
+            source_keys_dir_stat.stat.isdir is defined and
+            source_keys_dir_stat.stat.isdir
           }}
       when: inventory_hostname == source_host
 
@@ -31,15 +31,15 @@
     - name: precheck - Get stats of destination validator directory
       ansible.builtin.stat:
         path: "{{ destination_host_keys_dir }}"
-      register: destination_validator_keys_dir
+      register: destination_keys_dir_stat
       when: inventory_hostname == destination_host
 
     - name: precheck - Set destination directory validation fact
       ansible.builtin.set_fact:
         destination_dir_valid: >-
           {{
-            destination_validator_keys_dir.stat.isdir is defined and
-            destination_validator_keys_dir.stat.isdir
+            destination_keys_dir_stat.stat.isdir is defined and
+            destination_keys_dir_stat.stat.isdir
           }}
       when: inventory_hostname == destination_host
 

--- a/ansible/roles/solana_swap_validator_hosts_v2/README.md
+++ b/ansible/roles/solana_swap_validator_hosts_v2/README.md
@@ -15,7 +15,7 @@
 
 **RBAC-enabled hosts:**
 
-- Keys directory: `{{ validator_key_store }}/{{ validator_name }}` → `/opt/validator/keys/{{ validator_name }}`
+- Keys directory: `{{ validator_keys_dir }}/{{ validator_name }}` → `/opt/validator/keys/{{ validator_name }}`
 - Solana binaries: `{{ system_solana_active_release_dir }}` → `/opt/solana/active_release/bin` (system-wide)
 - Scripts: `{{ validator_scripts_dir }}` → `/opt/validator/scripts`
 - Logs: `{{ validator_logs_dir }}` → `/opt/validator/logs`
@@ -106,7 +106,7 @@ All three must exist for `validator_rbac_enabled` to be `true`.
 | `solana_user_dir` | N/A (not used) |
 | `scripts_dir` | `validator_scripts_dir` |
 | `logs_dir` | `validator_logs_dir` |
-| `keys_dir` | `validator_key_store` |
+| `keys_dir` | `validator_keys_dir` |
 | `default_group` | `validator_operators_group` |
 | `default_file_mode` | `validator_key_file_mode` |
 | `default_directory_mode` | `validator_data_mode_owner_readonly` |
@@ -183,7 +183,7 @@ Validator host swap operation happens in `tasks/swap.yml`. Here is a step by ste
 
 This role is designed for RBAC-enabled validator hosts and uses the following RBAC-specific configurations:
 
-- **Key Storage**: Keys are stored in `{{ validator_key_store }}/{{ validator_name }}` (typically `/opt/validator/keys/{{ validator_name }}`)
+- **Key Storage**: Keys are stored in `{{ validator_keyset_dir }}` (typically `/opt/validator/keys/{{ validator_name }}`)
 - **Binary Paths**: Solana binaries are accessed from `{{ system_solana_active_release_dir }}` (system-wide installation)
 - **File Ownership**: All identity files and symlinks are owned by `sol:validator_operators`
 - **File Permissions**: Key files use `{{ validator_key_file_mode }}` (0464) for secure group-based access

--- a/ansible/roles/solana_swap_validator_hosts_v2/tasks/deprovision_source_host.yml
+++ b/ansible/roles/solana_swap_validator_hosts_v2/tasks/deprovision_source_host.yml
@@ -149,7 +149,7 @@
 
     - name: Step 3 - Directories - Remove host keys directory
       ansible.builtin.file:
-        path: "{{ validator_key_store }}"
+        path: "{{ validator_keys_dir }}"
         state: absent
       become: true
       failed_when: false

--- a/ansible/roles/solana_swap_validator_hosts_v2/vars/main.yml
+++ b/ansible/roles/solana_swap_validator_hosts_v2/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-source_host_keys_dir: "{{ validator_key_store }}/{{ source_validator_name }}"
+source_host_keys_dir: "{{ validator_keys_dir }}/{{ source_validator_name }}"
 source_host_identity_link_path: "{{ source_host_keys_dir }}/identity.json"
 source_vote_account_path: "{{ source_host_keys_dir }}/vote-account.json"
-destination_host_keys_dir: "{{ validator_key_store }}/{{ destination_validator_name }}"
+destination_host_keys_dir: "{{ validator_keys_dir }}/{{ destination_validator_name }}"
 destination_host_identity_link_path: "{{ destination_host_keys_dir }}/identity.json"

--- a/ansible/roles/solana_validator_agave/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_agave/tasks/precheck.yml
@@ -1,17 +1,17 @@
 ---
-- name: Set value for validator_keys_dir
+- name: Set value for validator_keyset_dir
   ansible.builtin.set_fact:
-    validator_keys_dir: "{{ validator_key_store + '/' + validator_name }}"
+    validator_keyset_dir: "{{ validator_keys_dir + '/' + validator_name }}"
   run_once: true
 
-- name: precheck - Ensure the validator_keys_dir is defined and valid
+- name: precheck - Ensure the validator_keyset_dir is defined and valid
   ansible.builtin.assert:
     that:
-      - validator_keys_dir is defined
-      - validator_keys_dir == validator_key_store + "/" + validator_name
+      - validator_keyset_dir is defined
+      - validator_keyset_dir == validator_keys_dir + "/" + validator_name
     fail_msg: >
-      "Variable 'validator_keys_dir' must be defined."
-    success_msg: "validator_keys_dir is set to {{ validator_keys_dir }}"
+      "Variable 'validator_keyset_dir' must be defined."
+    success_msg: "validator_keyset_dir is set to {{ validator_keyset_dir }}"
 
 - name: precheck - Check if expected genesis hash is defined
   ansible.builtin.assert:

--- a/ansible/roles/solana_validator_agave/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_agave/tasks/prepare.yml
@@ -65,5 +65,5 @@
 
     rm -rf "{{ validator_logs_dir }}"/*
     rm -rf "{{ validator_scripts_dir }}"/*
-    rm -rf "{{ validator_key_store }}"/*
+    rm -rf "{{ validator_keys_dir }}"/*
   become: true

--- a/ansible/roles/solana_validator_agave/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.startup.j2
@@ -5,9 +5,9 @@ PATH="/bin:/usr/bin:{{ system_solana_active_release_dir }}"
 export SOLANA_METRICS_CONFIG="host={{ solana_metrics_url }}"
 {% endif %}
 exec agave-validator \
---identity "{{ validator_keys_dir }}/identity.json" \
+--identity "{{ validator_keyset_dir }}/identity.json" \
 --vote-account {{ vote_account_pubkey }} \
---authorized-voter {{ validator_keys_dir }}/primary-target-identity.json \
+--authorized-voter {{ validator_keyset_dir }}/primary-target-identity.json \
 {% for known_validator in known_validators %}
 --known-validator {{ known_validator }} \
 {% endfor %}

--- a/ansible/roles/solana_validator_agave/vars/main.yml
+++ b/ansible/roles/solana_validator_agave/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # Override the default validator directories with V2 values
-keys_dir: "{{ validator_key_store }}"
+keys_dir: "{{ validator_keys_dir }}"
 solana_install_dir: "{{ system_solana_active_release_dir }}"
 default_group: "{{ validator_operators_group }}"
 default_file_mode: "{{ validator_key_file_mode }}"

--- a/ansible/roles/solana_validator_jito/tasks/jito_client/configure/provision_keys.yml
+++ b/ansible/roles/solana_validator_jito/tasks/jito_client/configure/provision_keys.yml
@@ -1,9 +1,9 @@
 ---
 - name: Configure validator keys
   block:
-    - name: Ensure validator_keys_dir exists
+    - name: Ensure validator_keyset_dir exists
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}"
+        path: "{{ validator_keyset_dir }}"
         state: directory
         mode: '0755'
       tags: [jito_client, check.keys]
@@ -23,10 +23,10 @@
       when: not primary_target_identity_file.stat.exists
       tags: [jito_client, check.keys]
 
-    - name: Copy primary-target-identity.json to validator_keys_dir
+    - name: Copy primary-target-identity.json to validator_keyset_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/primary-target-identity.json"
-        dest: "{{ validator_keys_dir }}/primary-target-identity.json"
+        dest: "{{ validator_keyset_dir }}/primary-target-identity.json"
         mode: '0600'
       tags: [jito_client, check.keys]
 
@@ -45,10 +45,10 @@
       when: not vote_account_file.stat.exists
       tags: [jito_client, check.keys]
 
-    - name: Copy vote-account.json to validator_keys_dir
+    - name: Copy vote-account.json to validator_keyset_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/vote-account.json"
-        dest: "{{ validator_keys_dir }}/vote-account.json"
+        dest: "{{ validator_keyset_dir }}/vote-account.json"
         mode: '0600'
       tags: [jito_client, check.keys]
 
@@ -59,7 +59,7 @@
         . "$HOME/.bashrc"
         {{ solana_install_dir }}/solana-keygen new -s --no-bip39-passphrase -o hot-spare-identity.json -f
       args:
-        chdir: "{{ validator_keys_dir }}"
+        chdir: "{{ validator_keyset_dir }}"
       register: keygen_result
       tags: [jito_client, check.keys]
 
@@ -72,8 +72,8 @@
     # Create identity.json symlink based on validator_type
     - name: Create identity.json symlink
       ansible.builtin.file:
-        src: "{{ validator_keys_dir }}/{{ 'primary-target-identity.json' if validator_type == 'primary' else 'hot-spare-identity.json' }}"
-        dest: "{{ validator_keys_dir }}/identity.json"
+        src: "{{ validator_keyset_dir }}/{{ 'primary-target-identity.json' if validator_type == 'primary' else 'hot-spare-identity.json' }}"
+        dest: "{{ validator_keyset_dir }}/identity.json"
         state: link
         force: true
       tags: [jito_client, check.keys]

--- a/ansible/roles/solana_validator_jito/tasks/jito_relayer_cohosted/gen_relayer_keys.yml
+++ b/ansible/roles/solana_validator_jito/tasks/jito_relayer_cohosted/gen_relayer_keys.yml
@@ -1,15 +1,14 @@
----
-- name: Debug values for validator_keys_dir and ansible_keys_dir
+- name: Debug values for validator_keyset_dir and ansible_keys_dir
   ansible.builtin.debug:
     msg: |
       Source and destination keys directories
       =======================================
-      validator_keys_dir: {{ validator_keys_dir }}
+      validator_keyset_dir: {{ validator_keyset_dir }}
       ansible_keys_dir: {{ ansible_keys_dir }}
 
-- name: jito_relayer_cohosted - relayer_keys - Ensure validator_keys_dir exists
+- name: jito_relayer_cohosted - relayer_keys - Ensure validator_keyset_dir exists
   ansible.builtin.file:
-    path: "{{ validator_keys_dir }}"
+    path: "{{ validator_keyset_dir }}"
     state: directory
     mode: '0755'
   tags: [jito_relayer, check.keys]
@@ -33,13 +32,13 @@
 - name: jito_relayer_cohosted - relayer_keys - Copy Jito Relayer Block Engine key from ansible_keys_dir
   ansible.builtin.copy:
     src: "{{ ansible_keys_dir }}/jito-relayer-block-eng.json"
-    dest: "{{ validator_keys_dir }}/jito-relayer-block-eng.json"
+    dest: "{{ validator_keyset_dir }}/jito-relayer-block-eng.json"
     mode: '0600'
   tags: [jito_relayer, check.keys]
 
 - name: jito_relayer_cohosted - relayer_keys - Gen Comms Keys - Get stats of the RSA private key
   ansible.builtin.stat:
-    path: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+    path: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
   register: comms_private_key
   tags:
     - check.keys
@@ -48,16 +47,16 @@
   when:
     - not comms_private_key.stat.exists | default(false)
   ansible.builtin.shell: |
-    openssl genrsa --out {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem 2048
+    openssl genrsa --out {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem 2048
   args:
-    creates: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+    creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
   tags:
     - gen.keys.private
 
 - name: jito_relayer_cohosted - relayer_keys - Gen Comms Keys - Generate comms RSA public key
   ansible.builtin.shell: |
-    openssl rsa --in {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem --pubout --out {{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+    openssl rsa --in {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem --pubout --out {{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
   args:
-    creates: "{{ validator_keys_dir }}/jito-relayer-comms-pub.pem"
+    creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pub.pem"
   tags:
     - gen.keys.public

--- a/ansible/roles/solana_validator_jito/tasks/jito_relayer_cohosted/readme.md
+++ b/ansible/roles/solana_validator_jito/tasks/jito_relayer_cohosted/readme.md
@@ -288,10 +288,8 @@ WIP...
 
 | Variable                         | Default Value                                                        | Description                                                                                   |
 |----------------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `jito_relayer_install_dir`       | `/home/sol/.local/share/jito-relayer/install/active_release/release` | Path to the directory containing the built Jito relayer binary.                               |
-| `validator_keys_dir`             | `/home/sol/keys/{validator_name}`                                    | Directory where all key files (private/public keys, block engine keypair) are stored.         |
-| `jito_relayer_user`              | `sol`                                                                | The system user that runs the relayer and owns the files.                                     |
-| `jito_relayer_block_engine_url`  | `https://dallas.testnet.block-engine.jito.wtf`                       | The block engine URL to connect to (override for mainnet, etc.).                              |
+| `validator_keys_dir`             | `/opt/validator/keys`                                                | Base directory for validator keys (RBAC).                                                     |
+| `validator_keyset_dir`           | `/opt/validator/keys/{validator_name}`                               | Directory where specific validator keyset files are stored.                                   || `jito_relayer_block_engine_url`  | `https://dallas.testnet.block-engine.jito.wtf`                       | The block engine URL to connect to (override for mainnet, etc.).                              |
 | `jito_relayer_metrics_config`    | `host=http://metrics.jito.wtf:8086,db=relayer,u=relayer-operators,p=jito-relayer-write` | Metrics server configuration string.                                                          |
 
 **Note:** You should override these variables in your playbook or inventory as needed for your environment (e.g., for mainnet, different user, or custom paths).

--- a/ansible/roles/solana_validator_jito/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_jito/tasks/precheck.yml
@@ -33,14 +33,14 @@
       "The playbook variable 'validator_name' must be defined."
     success_msg: "validator_name is set to {{ validator_name }}"
 
-- name: Ensure the validator_keys_dir is defined and valid
+- name: Ensure the validator_keyset_dir is defined and valid
   ansible.builtin.assert:
     that:
-      - validator_keys_dir is defined
-      - validator_keys_dir == keys_dir + "/" + validator_name
+      - validator_keyset_dir is defined
+      - validator_keyset_dir == keys_dir + "/" + validator_name
     fail_msg: >
-      "Variable 'validator_keys_dir' must be defined."
-    success_msg: "validator_keys_dir is set to {{ validator_keys_dir }}"
+      "Variable 'validator_keyset_dir' must be defined."
+    success_msg: "validator_keyset_dir is set to {{ validator_keyset_dir }}"
 
 - name: Gather facts for localhost
   ansible.builtin.setup:

--- a/ansible/roles/solana_validator_jito/templates/jito-relayer.service.j2
+++ b/ansible/roles/solana_validator_jito/templates/jito-relayer.service.j2
@@ -4,9 +4,9 @@ Requires=network-online.target
 After=network-online.target
 
 # Ensure key files exist
-ConditionPathExists={{ validator_keys_dir }}/jito-relayer-block-eng.json
-ConditionPathExists={{ validator_keys_dir }}/jito-relayer-comms-pvt.pem
-ConditionPathExists={{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+ConditionPathExists={{ validator_keyset_dir }}/jito-relayer-block-eng.json
+ConditionPathExists={{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem
+ConditionPathExists={{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
 
 [Service]
 Type=exec
@@ -18,9 +18,9 @@ Environment=BLOCK_ENGINE_URL={{ jito_block_engine_url }}
 Environment=GRPC_BIND_IP=127.0.0.1
 
 ExecStart={{ jito_relayer_install_dir }}/jito-transaction-relayer \
-          --keypair-path={{ validator_keys_dir }}/jito-relayer-block-eng.json \
-          --signing-key-pem-path={{ validator_keys_dir }}/jito-relayer-comms-pvt.pem \
-          --verifying-key-pem-path={{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+          --keypair-path={{ validator_keyset_dir }}/jito-relayer-block-eng.json \
+          --signing-key-pem-path={{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem \
+          --verifying-key-pem-path={{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/solana_validator_jito/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_jito/templates/validator.startup.j2
@@ -5,9 +5,9 @@ PATH="/bin:/usr/bin:{{ solana_install_dir }}"
 export SOLANA_METRICS_CONFIG="host={{ solana_metrics_url }}"
 {% endif %}
 exec agave-validator \
---identity {{ validator_keys_dir }}/identity.json \
+--identity {{ validator_keyset_dir }}/identity.json \
 --vote-account {{ vote_account_pubkey }} \
---authorized-voter {{ validator_keys_dir }}/primary-target-identity.json \
+--authorized-voter {{ validator_keyset_dir }}/primary-target-identity.json \
 {% for known_validator in known_validators %}
 --known-validator {{ known_validator }} \
 {% endfor %}

--- a/ansible/roles/solana_validator_jito_v2/tasks/jito_relayer_cohosted/install.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/jito_relayer_cohosted/install.yml
@@ -3,9 +3,9 @@
   ansible.builtin.debug:
     msg: "Setting up Co-Hosted Jito Relayer"
 
-- name: jito_relayer_cohosted - install - Set validator keys directory
+- name: jito_relayer_cohosted - install - Set validator keyset directory
   ansible.builtin.set_fact:
-    validator_keys_dir: "{{ keys_dir }}/{{ validator_name }}"
+    validator_keyset_dir: "{{ keys_dir }}/{{ validator_name }}"
 
 - name: jito_relayer_cohosted - install - Install prerequisites
   become: true
@@ -26,7 +26,7 @@
   block:
     - name: jito_relayer_cohosted - install - Ensure keys directory exists
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}"
+        path: "{{ validator_keyset_dir }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
         mode: "{{ validator_data_mode_owner_readonly }}"
@@ -35,7 +35,7 @@
     - name: jito_relayer_cohosted - install - Copy jito-relayer-block-eng.json to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/jito-relayer-block-eng.json"
-        dest: "{{ validator_keys_dir }}/jito-relayer-block-eng.json"
+        dest: "{{ validator_keyset_dir }}/jito-relayer-block-eng.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -43,7 +43,7 @@
     - name: jito_relayer_cohosted - install - Copy Jito Relayer Comms private key to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/jito-relayer-comms-pvt.pem"
-        dest: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+        dest: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -51,20 +51,20 @@
 
     - name: jito_relayer_cohosted - install - Generate Jito Relayer Comms RSA private key on target host if not found on ansible host
       ansible.builtin.shell: |
-        openssl genrsa --out {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem 2048
+        openssl genrsa --out {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem 2048
       args:
-        creates: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+        creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
       when: not local_comms_key_exists.stat.exists | default(false)
 
     - name: jito_relayer_cohosted - install - Generate Jito Relayer Comms RSA public key on target host
       ansible.builtin.shell: |
-        openssl rsa -in {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem -pubout -out {{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+        openssl rsa -in {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem -pubout -out {{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
       args:
-        creates: "{{ validator_keys_dir }}/jito-relayer-comms-pub.pem"
+        creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pub.pem"
 
     - name: Fix ownership and permissions of keys
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}"
+        path: "{{ validator_keyset_dir }}"
         mode: "{{ validator_data_mode_owner_readonly }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"

--- a/ansible/roles/solana_validator_jito_v2/tasks/jito_relayer_cohosted/readme.md
+++ b/ansible/roles/solana_validator_jito_v2/tasks/jito_relayer_cohosted/readme.md
@@ -288,10 +288,8 @@ WIP...
 
 | Variable                         | Default Value                                                        | Description                                                                                   |
 |----------------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `jito_relayer_install_dir`       | `/home/sol/.local/share/jito-relayer/install/active_release/release` | Path to the directory containing the built Jito relayer binary.                               |
-| `validator_keys_dir`             | `/home/sol/keys/{validator_name}`                                    | Directory where all key files (private/public keys, block engine keypair) are stored.         |
-| `jito_relayer_user`              | `sol`                                                                | The system user that runs the relayer and owns the files.                                     |
-| `jito_relayer_block_engine_url`  | `https://dallas.testnet.block-engine.jito.wtf`                       | The block engine URL to connect to (override for mainnet, etc.).                              |
+| `validator_keys_dir`             | `/opt/validator/keys`                                                | Base directory for validator keys (RBAC).                                                     |
+| `validator_keyset_dir`           | `/opt/validator/keys/{validator_name}`                               | Directory where specific validator keyset files are stored.                                   || `jito_relayer_block_engine_url`  | `https://dallas.testnet.block-engine.jito.wtf`                       | The block engine URL to connect to (override for mainnet, etc.).                              |
 | `jito_relayer_metrics_config`    | `host=http://metrics.jito.wtf:8086,db=relayer,u=relayer-operators,p=jito-relayer-write` | Metrics server configuration string.                                                          |
 
 **Note:** You should override these variables in your playbook or inventory as needed for your environment (e.g., for mainnet, different user, or custom paths).

--- a/ansible/roles/solana_validator_jito_v2/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/precheck.yml
@@ -1,7 +1,7 @@
 ---
-- name: Set value for validator_keys_dir
+- name: Set value for validator_keyset_dir
   ansible.builtin.set_fact:
-    validator_keys_dir: "{{ validator_key_store + '/' + validator_name }}"
+    validator_keyset_dir: "{{ validator_keys_dir + '/' + validator_name }}"
 
 - name: Gather facts for localhost
   ansible.builtin.setup:

--- a/ansible/roles/solana_validator_jito_v2/tasks/prepare.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/prepare.yml
@@ -116,5 +116,5 @@
 
     rm -rf "{{ validator_logs_dir }}"/*
     rm -rf "{{ validator_scripts_dir }}"/*
-    rm -rf "{{ validator_key_store }}"/*
+    rm -rf "{{ validator_keys_dir }}"/*
   become: true

--- a/ansible/roles/solana_validator_jito_v2/templates/jito-relayer.service.j2
+++ b/ansible/roles/solana_validator_jito_v2/templates/jito-relayer.service.j2
@@ -4,9 +4,9 @@ Requires=network-online.target
 After=network-online.target
 
 # Ensure key files exist
-ConditionPathExists={{ validator_keys_dir }}/jito-relayer-block-eng.json
-ConditionPathExists={{ validator_keys_dir }}/jito-relayer-comms-pvt.pem
-ConditionPathExists={{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+ConditionPathExists={{ validator_keyset_dir }}/jito-relayer-block-eng.json
+ConditionPathExists={{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem
+ConditionPathExists={{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
 
 [Service]
 Type=exec
@@ -18,9 +18,9 @@ Environment=BLOCK_ENGINE_URL={{ jito_block_engine_url }}
 Environment=GRPC_BIND_IP=127.0.0.1
 
 ExecStart={{ jito_relayer_install_dir }}/jito-transaction-relayer \
-          --keypair-path={{ validator_keys_dir }}/jito-relayer-block-eng.json \
-          --signing-key-pem-path={{ validator_keys_dir }}/jito-relayer-comms-pvt.pem \
-          --verifying-key-pem-path={{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+          --keypair-path={{ validator_keyset_dir }}/jito-relayer-block-eng.json \
+          --signing-key-pem-path={{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem \
+          --verifying-key-pem-path={{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/solana_validator_jito_v2/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_jito_v2/templates/validator.startup.j2
@@ -5,9 +5,9 @@ PATH="/bin:/usr/bin:{{ system_solana_active_release_dir }}"
 export SOLANA_METRICS_CONFIG="host={{ solana_metrics_url }}"
 {% endif %}
 exec agave-validator \
---identity {{ validator_keys_dir }}/identity.json \
+--identity {{ validator_keyset_dir }}/identity.json \
 --vote-account {{ vote_account_pubkey }} \
---authorized-voter {{ validator_keys_dir }}/primary-target-identity.json \
+--authorized-voter {{ validator_keyset_dir }}/primary-target-identity.json \
 {% for known_validator in known_validators %}
 --known-validator {{ known_validator }} \
 {% endfor %}

--- a/ansible/roles/solana_validator_jito_v2/vars/main.yml
+++ b/ansible/roles/solana_validator_jito_v2/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # Override the default validator directories with V2 values
-keys_dir: "{{ validator_key_store }}"
+keys_dir: "{{ validator_keys_dir }}"
 solana_install_dir: "{{ system_solana_active_release_dir }}"
 default_group: "{{ validator_operators_group }}"
 default_file_mode: "{{ validator_key_file_mode }}"

--- a/ansible/roles/solana_validator_keyset/tasks/precheck.yml
+++ b/ansible/roles/solana_validator_keyset/tasks/precheck.yml
@@ -23,7 +23,7 @@
 - name: precheck - Set keys dir for local ansible control host and target host
   ansible.builtin.set_fact:
     ansible_keys_dir: "{{ ansible_home_dir }}/.validator-keys/{{ validator_keyset_name }}"
-    validator_keys_dir: "{{ keys_dir }}/{{ validator_keyset_name }}"
+    validator_keyset_dir: "{{ keys_dir }}/{{ validator_keyset_name }}"
 
 - name: precheck - Ensure a validator is installed
   block:

--- a/ansible/roles/solana_validator_shared/tasks/install_validator_keyset.yml
+++ b/ansible/roles/solana_validator_shared/tasks/install_validator_keyset.yml
@@ -58,7 +58,7 @@
   block:
     - name: install_validator_keyset - Set validator keys directory
       ansible.builtin.set_fact:
-        validator_keys_dir: "{{ keys_dir }}/{{ validator_name }}"
+        validator_keyset_dir: "{{ keys_dir }}/{{ validator_name }}"
         ansible_keys_dir: "{{ ansible_home_dir }}/.validator-keys/{{ validator_keyset_name }}"
 
     - name: install_validator_keyset - Check if hot-spare-identity.json exists in ansible_keys_dir
@@ -91,9 +91,9 @@
         set -e
         rm -rf "{{ keys_dir }}"/*
 
-    - name: install_validator_keyset - Ensure validator_keys_dir exists
+    - name: install_validator_keyset - Ensure validator_keyset_dir exists
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}"
+        path: "{{ validator_keyset_dir }}"
         state: directory
         mode: "{{ default_directory_mode }}"
         owner: "{{ solana_user }}"
@@ -106,7 +106,7 @@
     - name: install_validator_keyset - Copy primary-target-identity.json to target host
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/primary-target-identity.json"
-        dest: "{{ validator_keys_dir }}/primary-target-identity.json"
+        dest: "{{ validator_keyset_dir }}/primary-target-identity.json"
         mode: "{{ default_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ default_group }}"
@@ -115,7 +115,7 @@
     - name: install_validator_keyset - Copy vote-account.json to target host
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/vote-account.json"
-        dest: "{{ validator_keys_dir }}/vote-account.json"
+        dest: "{{ validator_keyset_dir }}/vote-account.json"
         mode: "{{ default_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ default_group }}"
@@ -124,7 +124,7 @@
     - name: install_validator_keyset - Copy hot-spare-identity.json to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/hot-spare-identity.json"
-        dest: "{{ validator_keys_dir }}/hot-spare-identity.json"
+        dest: "{{ validator_keyset_dir }}/hot-spare-identity.json"
         mode: "{{ default_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ default_group }}"
@@ -134,7 +134,7 @@
     - name: install_validator_keyset - Generate hot-spare-identity.json keypair
       ansible.builtin.shell: "{{ solana_install_dir }}/solana-keygen new -s --no-bip39-passphrase -o hot-spare-identity.json -f"
       args:
-        chdir: "{{ validator_keys_dir }}"
+        chdir: "{{ validator_keyset_dir }}"
       register: keygen_result
       when: not local_hot_spare_key_exists.stat.exists | default(false)
 
@@ -148,8 +148,8 @@
 
     - name: install_validator_keyset - Create identity.json symlink
       ansible.builtin.file:
-        src: "{{ validator_keys_dir }}/{{ 'primary-target-identity.json' if validator_type == 'primary' else 'hot-spare-identity.json' }}"
-        dest: "{{ validator_keys_dir }}/identity.json"
+        src: "{{ validator_keyset_dir }}/{{ 'primary-target-identity.json' if validator_type == 'primary' else 'hot-spare-identity.json' }}"
+        dest: "{{ validator_keyset_dir }}/identity.json"
         state: link
         force: true
   when: not (validator_rbac_enabled | default(false))
@@ -159,7 +159,7 @@
     - name: install_validator_keyset - Copy jito-relayer-block-eng.json to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/jito-relayer-block-eng.json"
-        dest: "{{ validator_keys_dir }}/jito-relayer-block-eng.json"
+        dest: "{{ validator_keyset_dir }}/jito-relayer-block-eng.json"
         mode: "{{ default_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ default_group }}"
@@ -169,7 +169,7 @@
     - name: install_validator_keyset - Generate jito-relayer-block-eng.json keypair
       ansible.builtin.shell: "{{ solana_install_dir }}/solana-keygen new -s --no-bip39-passphrase -o jito-relayer-block-eng.json -f"
       args:
-        chdir: "{{ validator_keys_dir }}"
+        chdir: "{{ validator_keyset_dir }}"
       register: jito_keygen_result
       when: not local_jito_key_exists.stat.exists | default(false)
 
@@ -181,7 +181,7 @@
     - name: install_validator_keyset - Copy Jito Relayer Comms private key to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/jito-relayer-comms-pvt.pem"
-        dest: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+        dest: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
         mode: "{{ default_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ default_group }}"
@@ -190,16 +190,16 @@
 
     - name: install_validator_keyset - Generate Jito Relayer Comms RSA private key on target host if not found on ansible host
       ansible.builtin.shell: |
-        openssl genrsa --out {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem 2048
+        openssl genrsa --out {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem 2048
       args:
-        creates: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+        creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
       when: not local_comms_key_exists.stat.exists | default(false)
 
     - name: install_validator_keyset - Generate Jito Relayer Comms RSA public key on target host
       ansible.builtin.shell: |
-        openssl rsa -in {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem -pubout -out {{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+        openssl rsa -in {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem -pubout -out {{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
       args:
-        creates: "{{ validator_keys_dir }}/jito-relayer-comms-pub.pem"
+        creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pub.pem"
   when: ((target_host_running_jito_relayer | default(false)) or ((jito_relayer_type is defined) and (jito_relayer_type == 'co-hosted'))) and (not (validator_rbac_enabled | default(false)))
 
 # Include RBAC tasks if enabled

--- a/ansible/roles/solana_validator_shared/tasks/install_validator_keyset_rbac.yml
+++ b/ansible/roles/solana_validator_shared/tasks/install_validator_keyset_rbac.yml
@@ -6,7 +6,7 @@
       - validator_keyset_name is defined
       - validator_type is defined
       - validator_type in ['primary', 'hot-spare']
-      - validator_key_store is defined
+      - validator_keys_dir is defined
       - solana_user is defined
       - system_solana_active_release_dir is defined
       - ansible_home_dir is defined
@@ -16,7 +16,7 @@
   block:
     - name: install_validator_keyset_rbac - Set validator keys directory
       ansible.builtin.set_fact:
-        validator_keys_dir: "{{ validator_key_store }}/{{ validator_name }}"
+        validator_keyset_dir: "{{ validator_keys_dir }}/{{ validator_name }}"
         ansible_keys_dir: "{{ ansible_home_dir }}/.validator-keys/{{ validator_keyset_name }}"
 
     - name: install_validator_keyset_rbac - Check if hot-spare-identity.json exists in ansible_keys_dir
@@ -42,15 +42,15 @@
 
 - name: install_validator_keyset_rbac - Reset validator keys directory
   block:
-    - name: install_validator_keyset_rbac - Remove validator key store
+    - name: install_validator_keyset_rbac - Remove validator keys directory contents
       ansible.builtin.shell: |
         #!/bin/bash
         set -e
-        rm -rf "{{ validator_key_store }}"/*
+        rm -rf "{{ validator_keys_dir }}"/*
 
-    - name: install_validator_keyset_rbac - Ensure validator_keys_dir exists
+    - name: install_validator_keyset_rbac - Ensure validator_keyset_dir exists
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}"
+        path: "{{ validator_keyset_dir }}"
         state: directory
         mode: "{{ validator_data_mode_owner_readonly }}"
         owner: "{{ solana_user }}"
@@ -62,7 +62,7 @@
     - name: install_validator_keyset_rbac - Copy primary-target-identity.json to target host
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/primary-target-identity.json"
-        dest: "{{ validator_keys_dir }}/primary-target-identity.json"
+        dest: "{{ validator_keyset_dir }}/primary-target-identity.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -71,7 +71,7 @@
     - name: install_validator_keyset_rbac - Copy vote-account.json to target host
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/vote-account.json"
-        dest: "{{ validator_keys_dir }}/vote-account.json"
+        dest: "{{ validator_keyset_dir }}/vote-account.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -80,7 +80,7 @@
     - name: install_validator_keyset_rbac - Copy hot-spare-identity.json to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/hot-spare-identity.json"
-        dest: "{{ validator_keys_dir }}/hot-spare-identity.json"
+        dest: "{{ validator_keyset_dir }}/hot-spare-identity.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -90,7 +90,7 @@
     - name: install_validator_keyset_rbac - Generate hot-spare-identity.json keypair
       ansible.builtin.shell: "{{ system_solana_active_release_dir }}/solana-keygen new -s --no-bip39-passphrase -o hot-spare-identity.json -f"
       args:
-        chdir: "{{ validator_keys_dir }}"
+        chdir: "{{ validator_keyset_dir }}"
       register: keygen_result
       become: true
       when: not local_hot_spare_key_exists.stat.exists | default(false)
@@ -105,15 +105,15 @@
 
     - name: install_validator_keyset_rbac - Create identity.json symlink
       ansible.builtin.file:
-        src: "{{ validator_keys_dir }}/{{ 'primary-target-identity.json' if validator_type == 'primary' else 'hot-spare-identity.json' }}"
-        dest: "{{ validator_keys_dir }}/identity.json"
+        src: "{{ validator_keyset_dir }}/{{ 'primary-target-identity.json' if validator_type == 'primary' else 'hot-spare-identity.json' }}"
+        dest: "{{ validator_keyset_dir }}/identity.json"
         state: link
         force: true
       become: true
 
     - name: Fix ownership of identity.json symlink
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}/identity.json"
+        path: "{{ validator_keyset_dir }}/identity.json"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
         follow: false
@@ -121,7 +121,7 @@
 
     - name: Fix ownership of hot-spare-identity.json
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}/hot-spare-identity.json"
+        path: "{{ validator_keyset_dir }}/hot-spare-identity.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -132,7 +132,7 @@
     - name: install_validator_keyset_rbac - Copy jito-relayer-block-eng.json to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/jito-relayer-block-eng.json"
-        dest: "{{ validator_keys_dir }}/jito-relayer-block-eng.json"
+        dest: "{{ validator_keyset_dir }}/jito-relayer-block-eng.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -142,7 +142,7 @@
     - name: install_validator_keyset_rbac - Generate jito-relayer-block-eng.json keypair
       ansible.builtin.shell: "{{ system_solana_active_release_dir }}/solana-keygen new -s --no-bip39-passphrase -o jito-relayer-block-eng.json -f"
       args:
-        chdir: "{{ validator_keys_dir }}"
+        chdir: "{{ validator_keyset_dir }}"
       register: jito_keygen_result
       become: true
       when: not local_jito_key_exists.stat.exists | default(false)
@@ -154,7 +154,7 @@
 
     - name: Fix ownership of jito-relayer-block-eng.json
       ansible.builtin.file:
-        path: "{{ validator_keys_dir }}/jito-relayer-block-eng.json"
+        path: "{{ validator_keyset_dir }}/jito-relayer-block-eng.json"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -163,7 +163,7 @@
     - name: install_validator_keyset_rbac - Copy Jito Relayer Comms private key to target host if it exists on ansible_keys_dir
       ansible.builtin.copy:
         src: "{{ ansible_keys_dir }}/jito-relayer-comms-pvt.pem"
-        dest: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+        dest: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
         mode: "{{ validator_key_file_mode }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
@@ -172,16 +172,16 @@
 
     - name: install_validator_keyset_rbac - Generate Jito Relayer Comms RSA private key on target host if not found on ansible host
       ansible.builtin.shell: |
-        openssl genrsa --out {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem 2048
+        openssl genrsa --out {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem 2048
       args:
-        creates: "{{ validator_keys_dir }}/jito-relayer-comms-pvt.pem"
+        creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem"
       become: true
       when: not local_comms_key_exists.stat.exists | default(false)
 
     - name: install_validator_keyset_rbac - Generate Jito Relayer Comms RSA public key on target host
       ansible.builtin.shell: |
-        openssl rsa -in {{ validator_keys_dir }}/jito-relayer-comms-pvt.pem -pubout -out {{ validator_keys_dir }}/jito-relayer-comms-pub.pem
+        openssl rsa -in {{ validator_keyset_dir }}/jito-relayer-comms-pvt.pem -pubout -out {{ validator_keyset_dir }}/jito-relayer-comms-pub.pem
       args:
-        creates: "{{ validator_keys_dir }}/jito-relayer-comms-pub.pem"
+        creates: "{{ validator_keyset_dir }}/jito-relayer-comms-pub.pem"
       become: true
   when: (target_host_running_jito_relayer | default(false)) or ((jito_relayer_type is defined) and (jito_relayer_type == 'co-hosted'))

--- a/ansible/roles/solana_validator_shared/tasks/setup_validator_directory.yml
+++ b/ansible/roles/solana_validator_shared/tasks/setup_validator_directory.yml
@@ -7,7 +7,7 @@
       - validator_root_dir is defined
       - validator_scripts_dir is defined
       - validator_logs_dir is defined
-      - validator_key_store is defined
+      - validator_keys_dir is defined
       - validator_root_dir_mode is defined
       - validator_scripts_dir_mode is defined
       - validator_data_mode_owner_writable is defined
@@ -39,7 +39,7 @@
     # /opt/validator/keys, sol:validator_operators, 575
     - name: Ensure solana keys directory exists
       ansible.builtin.file:
-        path: "{{ validator_key_store }}"
+        path: "{{ validator_keys_dir }}"
         owner: "{{ solana_user }}"
         group: "{{ validator_operators_group }}"
         mode: "{{ validator_data_mode_owner_readonly }}"

--- a/ansible/roles/solana_validator_shared/vars/main.yml
+++ b/ansible/roles/solana_validator_shared/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 jito_relayer_install_dir: "{{ solana_user_dir }}/.local/share/jito-relayer/install/active_release"
 ansible_keys_dir: "{{ ansible_home_dir }}/.validator-keys/{{ validator_keyset_name | default(validator_name) }}"
-validator_keys_dir: "{{ keys_dir }}/{{ validator_name }}"
+validator_keyset_dir: "{{ keys_dir }}/{{ validator_name }}"
 default_group: "{{ solana_user | default('') }}"
 default_file_mode: "0600"
 default_directory_mode: "0755"


### PR DESCRIPTION
# Renamed Validator Variable validator_key_store

## 📝 Summary

The validator key variables were renamed to improve consistency and resolved naming collisions. The primary focus was renaming `validator_key_store` to `validator_keys_dir` for RBAC-enabled hosts and disambiguating the existing `validator_keys_dir` by renaming it to `validator_keyset_dir`.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🚀 Performance improvement
- [x] ♻️ Code refactoring (no functional changes)

## 🔍 Scope & Complexity

**Please keep PRs focused and small for faster reviews.**

- [x] This PR changes **fewer than 400 lines** of code (excluding generated files)
- [x] This PR addresses **only one logical change** or feature
- [x] This PR can be **reviewed in under 30 minutes**
- [ ] This PR does **not mix multiple types of changes** (e.g., refactoring + new features)

If any of the above are unchecked, consider breaking this PR into smaller, focused changes.

## Changes Made

### Variable Renaming

- **Global Configuration**: Renamed `validator_key_store` to `validator_keys_dir` in [ansible/group_vars/solana.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/group_vars/solana.yml:0:0-0:0).
- **Core Facts**: Renamed the older `validator_keys_dir` (which referred to the specific keyset directory) to `validator_keyset_dir` across all roles.

### Role & Template Updates

- **Shared Tasks**: Updated [setup_validator_directory.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/roles/solana_validator_shared/tasks/setup_validator_directory.yml:0:0-0:0), [install_validator_keyset.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/roles/solana_validator_shared/tasks/install_validator_keyset.yml:0:0-0:0), and [install_validator_keyset_rbac.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/roles/solana_validator_shared/tasks/install_validator_keyset_rbac.yml:0:0-0:0) in the `solana_validator_shared` role.
- **Validator Roles**: Updated `solana_validator_jito`, `solana_validator_jito_v2`, and `solana_validator_agave` roles, including their startup scripts and service templates.
- **Swap Playbook**: Updated [pb_hot_swap_validator_hosts_v2.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/playbooks/pb_hot_swap_validator_hosts_v2.yml:0:0-0:0) to use the new standardized names.

## 🧪 Testing

- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Manual testing completed
- [ ] Existing functionality verified unchanged
- [ ] Documentation updated (if applicable)

### Test Details

### Verification Checks

- **Ansible Syntax Check**: Successfully passed `ansible-playbook --syntax-check` on all major playbooks:
    - [pb_hot_swap_validator_hosts_v2.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/playbooks/pb_hot_swap_validator_hosts_v2.yml:0:0-0:0)
    - [pb_setup_validator_jito_v2.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/playbooks/pb_setup_validator_jito_v2.yml:0:0-0:0)
    - [pb_setup_validator_jito.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/playbooks/pb_setup_validator_jito.yml:0:0-0:0)
    - [pb_setup_validator_agave.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/playbooks/pb_setup_validator_agave.yml:0:0-0:0)
- **Grep Audit**: Confirmed total removal of functional `validator_key_store` references.
- **Path Validation**: Verified that `validator_keyset_dir` correctly points to leaf directories (e.g., `/opt/validator/keys/demo2`) while `validator_keys_dir` points to the base (`/opt/validator/keys`).
- **Structural Integrity**: All templates and tasks have been updated to use the new variables, ensuring that identity file paths and symlinks are correctly established.

### Manual checks

#### RBAC enabled playbooks (v2)

- Playbook run `pb_setup_users_validator.yml` against `host-bravo`
- Playbook run `pb_setup_validator_agave.yml` against `host-bravo` to also verify roles `rust_env_v2` and `solana_validator_agave`
- Playbook run `pb_setup_validator_agave.yml` against `host-charlie` as hot-spare to later perform a swap
- Playbook run `pb_hot_swap_validator_hosts_v2.yml` between `host-bravo` and `host-charlie` to also verify

The above manual checks had the following role dependencies which also ran:

- `rust_env_v2`
- `solana_validator_agave`

#### Legacy playbooks (v1)

- Playbook run `pb_setup_validator_jito.yml` against `host-alpha`

#### Shared tasks also verified because they are included (used by) tested roles:

- `common/tasks/check_minimum_disk_space.yml`
- `common/tasks/convert_to_bytes.yml`
- `common/tasks/fallback_disk_space.yml`
- `common/tasks/set_host_architecture.yml`
- `solana_validator_shared/tasks/cleanup_validator_data.yml`
- `solana_validator_shared/tasks/detect_validator_rbac_mode.yml`
- `solana_validator_shared/tasks/install_validator_keyset.yml`
- `solana_validator_shared/tasks/install_validator_keyset_rbac.yml`
- `solana_validator_shared/tasks/setup_validator_directory.yml`

## 📚 Documentation

- [ ] Updated relevant documentation
- [ ] Added/updated comments for complex logic
- [x] README updated (if applicable)
- [ ] No documentation changes needed

### Documentation & Cleanup

- Updated role [README.md](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/roles/solana_swap_validator_hosts_v2/README.md:0:0-0:0) and relayer documentation for `solana_swap_validator_hosts_v2` and Jito roles.
- Renamed register variables in precheck tasks (e.g., `source_keys_dir_stat`) to avoid naming collisions with global facts.
- Fixed a YAML lint error (duplicate `args` key) in [install_validator_keyset.yml](cci:7://file:///Users/yamel/Projects/hayek-validator-kit-yaf/ansible/roles/solana_validator_shared/tasks/install_validator_keyset.yml:0:0-0:0).

## 🔗 Related Issues

Closes #168 

## 📝 Review Notes

Any specific areas you'd like reviewers to focus on or context they should know:

---

## For Reviewers

**Estimated review time:** ⏱️ [X minutes]

**Focus areas:**
- [x] Logic correctness
- [ ] Security implications
- [ ] Performance impact
- [ ] Documentation completeness