### PR TITLE
Allow post-swap vote account verification in localnet cluster

### DIFF
--- a/ansible/roles/solana_swap_validator_hosts_v2/tasks/verify.yml
+++ b/ansible/roles/solana_swap_validator_hosts_v2/tasks/verify.yml
@@ -330,7 +330,6 @@
         - vote_account_after is defined
         - vote_account_after.epochVotingHistory is defined
         - vote_account_after.epochVotingHistory | length > 0
-  when: solana_cluster != 'localnet'
 
 - name: verify - Calculate TVC impact
   block:


### PR DESCRIPTION
Tested with:

```sh
hvk-test run \
  --target compose \
  --scenario hot_swap_matrix \
  --verify-cmd '"$HVK_REPO_ROOT/test-harness/scripts/verify-compose-hot-swap.sh" --inventory "$HVK_INVENTORY_PATH" --source-flavor agave --destination-flavor jito-bam'
```