### PR TITLE
Add concurrency guards to sfdp-watch and binary-pipeline workflows

### DIFF
--- a/.github/workflows/solana-binary-pipeline.yml
+++ b/.github/workflows/solana-binary-pipeline.yml
@@ -64,6 +64,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: binary-build-${{ inputs.client }}-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/solana-sfdp-watch.yml
+++ b/.github/workflows/solana-sfdp-watch.yml
@@ -47,6 +47,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: solana-sfdp-watch
+  cancel-in-progress: false
+
 jobs:
   watch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **`solana-sfdp-watch`**: adds a top-level `concurrency` group (`solana-sfdp-watch`, `cancel-in-progress: false`) so that a manual trigger and an imminent scheduled run queue rather than race each other — preventing both from dispatching duplicate builds for the same missing versions.
- **`solana-binary-pipeline`**: adds a `concurrency` group keyed on `client + version` (`binary-build-{client}-{version}`, `cancel-in-progress: false`) so that a second dispatch for the same pair queues and then fails cheaply at the `force_overwrite` guard instead of after a full ~2-hour Rust compile.

`cancel-in-progress: false` is intentional for both: cancelling the in-progress run would discard hours of compile time. The queued duplicate is the one that pays the cheap failure cost.

The `concurrency` key does not include `arch` for the pipeline — builds for the same version but different architectures run on separate runners and should remain parallel.

## Test plan

- [ ] Trigger `solana-sfdp-watch` manually, then immediately trigger it again — the second run should show **"Waiting for a pending workflow run"** in the Actions UI.
- [ ] After the first completes the second starts and produces an identical Step Summary.
- [ ] Trigger `solana-binary-pipeline` twice for the same `client` + `version` — confirm the second run is queued and the first proceeds uninterrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)