### PR TITLE
Add XDP Hardware Metrics Panels

### DIFF
--- a/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
+++ b/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
@@ -47,8 +47,9 @@
       {{
         deploy_grafana_api_base_url
         | default(
-            ((ssl_enabled | default(false) | bool) | ternary('https', 'http'))
-            ~ '://127.0.0.1:'
+            'http://'
+            ~ (monitoring_network.bind_address | default('localhost'))
+            ~ ':'
             ~ ((grafana_port | default(3000)) | string)
           )
       }}

--- a/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
+++ b/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
@@ -53,7 +53,9 @@
           )
       }}
     hardware_dashboard_render_path: "/tmp/hayek-hardware-metrics-dashboard.json"
+    hardware_dashboard_staging_path: "/tmp/hayek-hardware-metrics-dashboard.next.json"
     validator_dashboard_render_path: "/tmp/hayek-validator-metrics-dashboard.json"
+    validator_dashboard_staging_path: "/tmp/hayek-validator-metrics-dashboard.next.json"
     monitoring_hub_vars_main_file_path: "{{ playbook_dir }}/../roles/monitoring_hub/vars/main.yml"
     monitoring_hub_secrets_file_path: "{{ playbook_dir }}/../roles/monitoring_hub/vars/secrets.yml"
     monitoring_hub_secrets_example_file_path: "{{ playbook_dir }}/../roles/monitoring_hub/vars/secrets.yml.example"
@@ -170,14 +172,39 @@
       vars:
         item: "{{ selected_network_item }}"
 
-    - name: Render hardware dashboard JSON change marker
+    - name: Render hardware dashboard JSON staging file
       ansible.builtin.copy:
         src: ../roles/monitoring_hub/templates/grafana/hardware_metrics.json
-        dest: "{{ hardware_dashboard_render_path }}"
+        dest: "{{ hardware_dashboard_staging_path }}"
         owner: root
         group: root
         mode: "0600"
-      register: deploy_hardware_dashboard_template_result
+      register: deploy_hardware_dashboard_staging_result
+      when: deploy_hardware_dashboard | default(true) | bool
+
+    - name: Check hardware dashboard import marker
+      ansible.builtin.stat:
+        path: "{{ hardware_dashboard_render_path }}"
+      register: deploy_hardware_dashboard_marker_stat
+      when: deploy_hardware_dashboard | default(true) | bool
+
+    - name: Check hardware dashboard staging file
+      ansible.builtin.stat:
+        path: "{{ hardware_dashboard_staging_path }}"
+      register: deploy_hardware_dashboard_staging_stat
+      when: deploy_hardware_dashboard | default(true) | bool
+
+    - name: Determine whether Hardware Metrics dashboard import is needed
+      ansible.builtin.set_fact:
+        deploy_hardware_dashboard_import_needed: >-
+          {{
+            deploy_hardware_dashboard_force | default(false) | bool or
+            not (deploy_hardware_dashboard_marker_stat.stat.exists | default(false)) or
+            (
+              deploy_hardware_dashboard_marker_stat.stat.checksum | default('') !=
+              deploy_hardware_dashboard_staging_stat.stat.checksum | default('')
+            )
+          }}
       when: deploy_hardware_dashboard | default(true) | bool
 
     - block:
@@ -194,9 +221,7 @@
       when:
         - deploy_hardware_dashboard | default(true) | bool
         - not ansible_check_mode
-        - >-
-          deploy_hardware_dashboard_force | default(false) | bool or
-          (deploy_hardware_dashboard_template_result is defined and deploy_hardware_dashboard_template_result.changed)
+        - deploy_hardware_dashboard_import_needed | default(false) | bool
 
     - name: Import Hardware Metrics dashboard into Grafana when changed
       ansible.builtin.uri:
@@ -226,16 +251,54 @@
         - hardware_dashboard_json is defined
       no_log: "{{ deploy_hide_sensitive_logs | default(true) | bool }}"
 
-    - name: Render validator dashboard JSON change marker
-      ansible.builtin.template:
-        src: ../roles/monitoring_hub/templates/grafana/validators_metrics.json.j2
-        dest: "{{ validator_dashboard_render_path }}"
+    - name: Update hardware dashboard import marker after successful import
+      ansible.builtin.copy:
+        src: "{{ hardware_dashboard_staging_path }}"
+        dest: "{{ hardware_dashboard_render_path }}"
+        remote_src: true
         owner: root
         group: root
         mode: "0600"
-      register: deploy_validator_dashboard_template_result
+      when:
+        - deploy_hardware_dashboard | default(true) | bool
+        - not ansible_check_mode
+        - hardware_dashboard_json is defined
+
+    - name: Render validator dashboard JSON staging file
+      ansible.builtin.template:
+        src: ../roles/monitoring_hub/templates/grafana/validators_metrics.json.j2
+        dest: "{{ validator_dashboard_staging_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+      register: deploy_validator_dashboard_staging_result
       vars:
         selected_network: "{{ target_network }}"
+      when: deploy_validator_dashboard | default(true) | bool
+
+    - name: Check validator dashboard import marker
+      ansible.builtin.stat:
+        path: "{{ validator_dashboard_render_path }}"
+      register: deploy_validator_dashboard_marker_stat
+      when: deploy_validator_dashboard | default(true) | bool
+
+    - name: Check validator dashboard staging file
+      ansible.builtin.stat:
+        path: "{{ validator_dashboard_staging_path }}"
+      register: deploy_validator_dashboard_staging_stat
+      when: deploy_validator_dashboard | default(true) | bool
+
+    - name: Determine whether Validator Metrics dashboard import is needed
+      ansible.builtin.set_fact:
+        deploy_validator_dashboard_import_needed: >-
+          {{
+            deploy_validator_dashboard_force | default(false) | bool or
+            not (deploy_validator_dashboard_marker_stat.stat.exists | default(false)) or
+            (
+              deploy_validator_dashboard_marker_stat.stat.checksum | default('') !=
+              deploy_validator_dashboard_staging_stat.stat.checksum | default('')
+            )
+          }}
       when: deploy_validator_dashboard | default(true) | bool
 
     - block:
@@ -254,9 +317,7 @@
       when:
         - deploy_validator_dashboard | default(true) | bool
         - not ansible_check_mode
-        - >-
-          deploy_validator_dashboard_force | default(false) | bool or
-          (deploy_validator_dashboard_template_result is defined and deploy_validator_dashboard_template_result.changed)
+        - deploy_validator_dashboard_import_needed | default(false) | bool
 
     - name: Import Validator Metrics dashboard into Grafana when changed
       ansible.builtin.uri:
@@ -290,6 +351,19 @@
         - validator_dashboard_json is defined
       no_log: "{{ deploy_hide_sensitive_logs | default(true) | bool }}"
 
+    - name: Update validator dashboard import marker after successful import
+      ansible.builtin.copy:
+        src: "{{ validator_dashboard_staging_path }}"
+        dest: "{{ validator_dashboard_render_path }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0600"
+      when:
+        - deploy_validator_dashboard | default(true) | bool
+        - not ansible_check_mode
+        - validator_dashboard_json is defined
+
     - name: Restart alert formatter service when script changed
       ansible.builtin.systemd:
         name: alert-formatter.service
@@ -304,9 +378,16 @@
         daemon_reload: true
       when: deploy_monitor_env_result.changed or deploy_validator_metrics_script_result.changed
 
+    - name: Check per-network Telegraf service unit exists
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/telegraf-{{ selected_network_item.value.network_name }}.service"
+      register: deploy_telegraf_service_unit_stat
+
     - name: Restart per-network Telegraf service when monitor script changed
       ansible.builtin.systemd:
         name: "telegraf-{{ selected_network_item.value.network_name }}.service"
         state: restarted
         daemon_reload: true
-      when: deploy_monitor_script_result.changed or deploy_force_telegraf_restart | default(false) | bool
+      when:
+        - deploy_telegraf_service_unit_stat.stat.exists
+        - deploy_monitor_script_result.changed or deploy_force_telegraf_restart | default(false) | bool

--- a/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
+++ b/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
@@ -179,7 +179,6 @@
         owner: root
         group: root
         mode: "0600"
-      register: deploy_hardware_dashboard_staging_result
       when: deploy_hardware_dashboard | default(true) | bool
 
     - name: Check hardware dashboard import marker
@@ -237,7 +236,7 @@
         body:
           dashboard: "{{ hardware_dashboard_json }}"
           overwrite: true
-          folderId: 0
+          folderUid: ""
           inputs:
             - name: "DS_INFLUXDB-1"
               type: "datasource"
@@ -245,6 +244,7 @@
               value: "{{ grafana_config.hardware_metrics_source_uid | default('hardware_metrics_uid') }}"
         status_code: 200
         timeout: 20
+      register: deploy_hardware_dashboard_import_result
       when:
         - deploy_hardware_dashboard | default(true) | bool
         - not ansible_check_mode
@@ -263,6 +263,7 @@
         - deploy_hardware_dashboard | default(true) | bool
         - not ansible_check_mode
         - hardware_dashboard_json is defined
+        - deploy_hardware_dashboard_import_result.status | default(0) == 200
 
     - name: Render validator dashboard JSON staging file
       ansible.builtin.template:
@@ -271,7 +272,6 @@
         owner: root
         group: root
         mode: "0600"
-      register: deploy_validator_dashboard_staging_result
       vars:
         selected_network: "{{ target_network }}"
       when: deploy_validator_dashboard | default(true) | bool
@@ -333,18 +333,15 @@
         body:
           dashboard: "{{ validator_dashboard_json }}"
           overwrite: true
-          folderId: 0
+          folderUid: ""
           inputs:
             - name: "DS_SOLANA_METRICS"
               type: "datasource"
               pluginId: "influxdb"
               value: "{{ grafana_config.solana_metrics_source_uid | default('solana_metrics_uid') }}"
-            - name: "DS_HAYEK_MAINNET STAKEWIZ ACTIVATING/DEACTIVATING STAKE JSON"
-              type: "datasource"
-              pluginId: "marcusolsson-json-datasource"
-              value: "stakewiz_json_mainnet_activating"
         status_code: 200
         timeout: 20
+      register: deploy_validator_dashboard_import_result
       when:
         - deploy_validator_dashboard | default(true) | bool
         - not ansible_check_mode
@@ -363,6 +360,7 @@
         - deploy_validator_dashboard | default(true) | bool
         - not ansible_check_mode
         - validator_dashboard_json is defined
+        - deploy_validator_dashboard_import_result.status | default(0) == 200
 
     - name: Restart alert formatter service when script changed
       ansible.builtin.systemd:
@@ -390,4 +388,7 @@
         daemon_reload: true
       when:
         - deploy_telegraf_service_unit_stat.stat.exists
-        - deploy_monitor_script_result.changed or deploy_force_telegraf_restart | default(false) | bool
+        - >-
+          deploy_monitor_script_result.changed or
+          deploy_monitor_env_result.changed or
+          deploy_force_telegraf_restart | default(false) | bool

--- a/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
+++ b/ansible/playbooks/pb_deploy_monitoring_templates_per_network.yml
@@ -19,6 +19,8 @@
 #   - monitor.sh.j2 (selected net) -> /etc/telegraf/scripts/monitor-<network>.sh
 #   - monitor.env.j2               -> /usr/local/etc/validator-metrics.env
 #   - validator-metrics.sh.j2      -> /usr/local/bin/validator-metrics.sh
+#   - hardware_metrics.json        -> Grafana dashboard import when JSON changes
+#   - validators_metrics.json.j2   -> Grafana dashboard import when rendered JSON changes
 
 - name: Deploy selected monitoring templates
   hosts: "{{ target_host }}"
@@ -41,6 +43,17 @@
     tmp_influxdb_default_bucket: "{{ deploy_tmp_influxdb_default_bucket | default('solana_metrics') }}"
     grafana_admin_password: "{{ deploy_grafana_admin_password | default('admin') }}"
     grafana_url: "{{ deploy_grafana_url | default('http://localhost:3000') }}"
+    grafana_import_api_base_url: >-
+      {{
+        deploy_grafana_api_base_url
+        | default(
+            ((ssl_enabled | default(false) | bool) | ternary('https', 'http'))
+            ~ '://127.0.0.1:'
+            ~ ((grafana_port | default(3000)) | string)
+          )
+      }}
+    hardware_dashboard_render_path: "/tmp/hayek-hardware-metrics-dashboard.json"
+    validator_dashboard_render_path: "/tmp/hayek-validator-metrics-dashboard.json"
     monitoring_hub_vars_main_file_path: "{{ playbook_dir }}/../roles/monitoring_hub/vars/main.yml"
     monitoring_hub_secrets_file_path: "{{ playbook_dir }}/../roles/monitoring_hub/vars/secrets.yml"
     monitoring_hub_secrets_example_file_path: "{{ playbook_dir }}/../roles/monitoring_hub/vars/secrets.yml.example"
@@ -153,8 +166,129 @@
         owner: telegraf
         group: telegraf
         mode: "0755"
+      register: deploy_monitor_script_result
       vars:
         item: "{{ selected_network_item }}"
+
+    - name: Render hardware dashboard JSON change marker
+      ansible.builtin.copy:
+        src: ../roles/monitoring_hub/templates/grafana/hardware_metrics.json
+        dest: "{{ hardware_dashboard_render_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+      register: deploy_hardware_dashboard_template_result
+      when: deploy_hardware_dashboard | default(true) | bool
+
+    - block:
+        - name: Load Hardware Metrics dashboard JSON
+          ansible.builtin.set_fact:
+            hardware_dashboard_json: "{{ lookup('file', playbook_dir + '/../roles/monitoring_hub/templates/grafana/hardware_metrics.json') | from_json }}"
+      rescue:
+        - name: Fail with helpful error if hardware dashboard JSON is invalid
+          ansible.builtin.fail:
+            msg: >-
+              Unable to load or parse the Hardware Metrics dashboard JSON file at
+              '{{ playbook_dir }}/../roles/monitoring_hub/templates/grafana/hardware_metrics.json'.
+              Please check that the file exists and contains valid JSON.
+      when:
+        - deploy_hardware_dashboard | default(true) | bool
+        - not ansible_check_mode
+        - >-
+          deploy_hardware_dashboard_force | default(false) | bool or
+          (deploy_hardware_dashboard_template_result is defined and deploy_hardware_dashboard_template_result.changed)
+
+    - name: Import Hardware Metrics dashboard into Grafana when changed
+      ansible.builtin.uri:
+        url: "{{ grafana_import_api_base_url }}/api/dashboards/import"
+        method: POST
+        user: "{{ grafana_default_admin_user }}"
+        password: "{{ grafana_secrets.admin_password }}"
+        force_basic_auth: true
+        headers:
+          Content-Type: "application/json"
+        body_format: json
+        validate_certs: "{{ deploy_grafana_validate_certs | default(false) | bool }}"
+        body:
+          dashboard: "{{ hardware_dashboard_json }}"
+          overwrite: true
+          folderId: 0
+          inputs:
+            - name: "DS_INFLUXDB-1"
+              type: "datasource"
+              pluginId: "influxdb"
+              value: "{{ grafana_config.hardware_metrics_source_uid | default('hardware_metrics_uid') }}"
+        status_code: 200
+        timeout: 20
+      when:
+        - deploy_hardware_dashboard | default(true) | bool
+        - not ansible_check_mode
+        - hardware_dashboard_json is defined
+      no_log: "{{ deploy_hide_sensitive_logs | default(true) | bool }}"
+
+    - name: Render validator dashboard JSON change marker
+      ansible.builtin.template:
+        src: ../roles/monitoring_hub/templates/grafana/validators_metrics.json.j2
+        dest: "{{ validator_dashboard_render_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+      register: deploy_validator_dashboard_template_result
+      vars:
+        selected_network: "{{ target_network }}"
+      when: deploy_validator_dashboard | default(true) | bool
+
+    - block:
+        - name: Render and load Validator Metrics dashboard JSON
+          ansible.builtin.set_fact:
+            validator_dashboard_json: "{{ lookup('template', playbook_dir + '/../roles/monitoring_hub/templates/grafana/validators_metrics.json.j2') | from_json }}"
+          vars:
+            selected_network: "{{ target_network }}"
+      rescue:
+        - name: Fail with helpful error if dashboard JSON is invalid
+          ansible.builtin.fail:
+            msg: >-
+              Unable to render or parse the Validator Metrics dashboard JSON using template lookup
+              at '{{ playbook_dir }}/../roles/monitoring_hub/templates/grafana/validators_metrics.json.j2'.
+              Please check that the file exists and contains valid JSON after templating.
+      when:
+        - deploy_validator_dashboard | default(true) | bool
+        - not ansible_check_mode
+        - >-
+          deploy_validator_dashboard_force | default(false) | bool or
+          (deploy_validator_dashboard_template_result is defined and deploy_validator_dashboard_template_result.changed)
+
+    - name: Import Validator Metrics dashboard into Grafana when changed
+      ansible.builtin.uri:
+        url: "{{ grafana_import_api_base_url }}/api/dashboards/import"
+        method: POST
+        user: "{{ grafana_default_admin_user }}"
+        password: "{{ grafana_secrets.admin_password }}"
+        force_basic_auth: true
+        headers:
+          Content-Type: "application/json"
+        body_format: json
+        validate_certs: "{{ deploy_grafana_validate_certs | default(false) | bool }}"
+        body:
+          dashboard: "{{ validator_dashboard_json }}"
+          overwrite: true
+          folderId: 0
+          inputs:
+            - name: "DS_SOLANA_METRICS"
+              type: "datasource"
+              pluginId: "influxdb"
+              value: "{{ grafana_config.solana_metrics_source_uid | default('solana_metrics_uid') }}"
+            - name: "DS_HAYEK_MAINNET STAKEWIZ ACTIVATING/DEACTIVATING STAKE JSON"
+              type: "datasource"
+              pluginId: "marcusolsson-json-datasource"
+              value: "stakewiz_json_mainnet_activating"
+        status_code: 200
+        timeout: 20
+      when:
+        - deploy_validator_dashboard | default(true) | bool
+        - not ansible_check_mode
+        - validator_dashboard_json is defined
+      no_log: "{{ deploy_hide_sensitive_logs | default(true) | bool }}"
 
     - name: Restart alert formatter service when script changed
       ansible.builtin.systemd:
@@ -169,3 +303,10 @@
         state: restarted
         daemon_reload: true
       when: deploy_monitor_env_result.changed or deploy_validator_metrics_script_result.changed
+
+    - name: Restart per-network Telegraf service when monitor script changed
+      ansible.builtin.systemd:
+        name: "telegraf-{{ selected_network_item.value.network_name }}.service"
+        state: restarted
+        daemon_reload: true
+      when: deploy_monitor_script_result.changed or deploy_force_telegraf_restart | default(false) | bool

--- a/ansible/roles/monitoring_hub/templates/grafana/hardware_metrics.json
+++ b/ansible/roles/monitoring_hub/templates/grafana/hardware_metrics.json
@@ -43,6 +43,12 @@
     },
     {
       "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
       "id": "timeseries",
       "name": "Time series",
       "version": ""
@@ -3237,6 +3243,513 @@
       "title": "Open File Descriptors",
       "transparent": true,
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 151,
+      "panels": [],
+      "title": "XDP Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB-1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Alert"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "id": 152,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 26
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "alias": "$tag_iface",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB-1}"
+          },
+          "query": "SELECT last(\"xdp_alert\") FROM \"xdp_status\" WHERE \"host\" =~ /^$server$/ AND $timeFilter GROUP BY \"host\", \"iface\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "XDP Health",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB-1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "Disabled"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Enabled"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 38
+      },
+      "id": 153,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 26
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "alias": "$tag_iface",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB-1}"
+          },
+          "query": "SELECT last(\"effective_enabled\") FROM \"xdp_status\" WHERE \"host\" =~ /^$server$/ AND $timeFilter GROUP BY \"host\", \"iface\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "XDP Enabled",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB-1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Missing"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Present"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 38
+      },
+      "id": 154,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 26
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "alias": "$tag_iface",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB-1}"
+          },
+          "query": "SELECT last(\"runtime_flags_present\") FROM \"xdp_status\" WHERE \"host\" =~ /^$server$/ AND $timeFilter GROUP BY \"host\", \"iface\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Runtime Flags",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB-1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Not Attached"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Attached"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 38
+      },
+      "id": 155,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 26
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "alias": "$tag_iface",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB-1}"
+          },
+          "query": "SELECT last(\"attach_detected\") FROM \"xdp_status\" WHERE \"host\" =~ /^$server$/ AND $timeFilter GROUP BY \"host\", \"iface\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "XDP Attach",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB-1}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "alert"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "OK"
+                      },
+                      "1": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Alert"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "state"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "active": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Active"
+                      },
+                      "active_numa_unverified": {
+                        "color": "yellow",
+                        "index": 1,
+                        "text": "Active, NUMA Unverified"
+                      },
+                      "disabled": {
+                        "color": "blue",
+                        "index": 2,
+                        "text": "Disabled"
+                      },
+                      "runtime_missing_flags": {
+                        "color": "red",
+                        "index": 3,
+                        "text": "Runtime Flags Missing"
+                      },
+                      "runtime_no_link_attach": {
+                        "color": "red",
+                        "index": 4,
+                        "text": "No Link Attach"
+                      },
+                      "validator_not_running": {
+                        "color": "orange",
+                        "index": 5,
+                        "text": "Validator Not Running"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 156,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB-1}"
+          },
+          "query": "SELECT last(\"xdp_alert\") AS \"alert\", last(\"requested\") AS \"requested\", last(\"effective_enabled\") AS \"enabled\", last(\"runtime_flags_present\") AS \"runtime_flags\", last(\"attach_detected\") AS \"attached\", last(\"alert_reason\") AS \"alert_reason\", last(\"skip_reason\") AS \"skip_reason\", last(\"numa_check_status\") AS \"numa_status\", last(\"numa_check_reason\") AS \"numa_reason\" FROM \"xdp_status\" WHERE \"host\" =~ /^$server$/ AND $timeFilter GROUP BY \"host\", \"iface\", \"state\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "XDP Details",
+      "transparent": true,
+      "type": "table"
     }
   ],
   "refresh": "5m",

--- a/ansible/roles/monitoring_hub/templates/grafana/validators_metrics.json.j2
+++ b/ansible/roles/monitoring_hub/templates/grafana/validators_metrics.json.j2
@@ -2058,6 +2058,9 @@
                 },
                 "3": {
                   "text": "Delinquent"
+                },
+                "5": {
+                  "text": "Not Active"
                 }
               },
               "type": "value"
@@ -2081,6 +2084,10 @@
               {
                 "color": "dark-red",
                 "value": 3
+              },
+              {
+                "color": "yellow",
+                "value": 5
               }
             ]
           },

--- a/ansible/roles/monitoring_hub/templates/telegraf/monitor.sh.j2
+++ b/ansible/roles/monitoring_hub/templates/telegraf/monitor.sh.j2
@@ -40,11 +40,17 @@ validatorBalance=$($cli balance $identityPubkey --url $rpcURL | grep -o '[0-9.]*
 validatorVoteBalance=$($cli balance $voteAccount --url $rpcURL | grep -o '[0-9.]*')
 solanaPrice=$(curl -s 'GET' 'https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd' -H 'accept: application/json' | jq -r .solana.usd)
 openfiles=$(cat /proc/sys/fs/file-nr | awk '{ print $1 }')
-validatorCheck=$($cli validators --url $rpcURL 2>/dev/null)
-validatorCheckRc=$?
-if [ "$validatorCheckRc" -ne 0 ] || [ -z "$validatorCheck" ]; then
+validatorCheck=""
+validatorCheckRc=1
+if [ -z "$voteAccount" ]; then
    validatorInSet=-1
 else
+   validatorCheck=$($cli validators --url $rpcURL 2>/dev/null)
+   validatorCheckRc=$?
+fi
+if [ -n "$voteAccount" ] && { [ "$validatorCheckRc" -ne 0 ] || [ -z "$validatorCheck" ]; }; then
+   validatorInSet=-1
+elif [ -n "$voteAccount" ]; then
    validatorInSet=$(grep -c "$voteAccount" <<< "$validatorCheck")
 fi
 
@@ -109,7 +115,7 @@ elif [ -n "$currentValidatorInfo" ]; then
    logentry="$logentry,version=$version2,pctNewerVersions=$pctNewerVersions,commission=$commission,activatedStake=$activatedStake,credits=$credits,solanaPrice=$solanaPrice"
 fi
 
-if [ "$additionalInfo" == "on" ]; then
+if [ "$additionalInfo" == "on" ] && { [ "$status" -eq 0 ] || [ "$status" -eq 3 ]; }; then
    nodes=$($cli gossip --url $rpcURL | grep -Po "Nodes:\s+\K[0-9]+")
    epochInfo=$($cli epoch-info --url $rpcURL --output json-compact)
    epoch=$(jq -r '.epoch' <<<$epochInfo)

--- a/ansible/roles/monitoring_hub/templates/telegraf/monitor.sh.j2
+++ b/ansible/roles/monitoring_hub/templates/telegraf/monitor.sh.j2
@@ -41,7 +41,12 @@ validatorVoteBalance=$($cli balance $voteAccount --url $rpcURL | grep -o '[0-9.]
 solanaPrice=$(curl -s 'GET' 'https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd' -H 'accept: application/json' | jq -r .solana.usd)
 openfiles=$(cat /proc/sys/fs/file-nr | awk '{ print $1 }')
 validatorCheck=$($cli validators --url $rpcURL 2>/dev/null)
-validatorInSet=$(grep -c "$voteAccount" <<< "$validatorCheck")
+validatorCheckRc=$?
+if [ "$validatorCheckRc" -ne 0 ] || [ -z "$validatorCheck" ]; then
+   validatorInSet=-1
+else
+   validatorInSet=$(grep -c "$voteAccount" <<< "$validatorCheck")
+fi
 
 blockProduction=$($cli block-production --url $rpcURL --output json-compact 2>&- | grep -v Note:)
 validatorBlockProduction=$(jq -r '.leaders[] | select(.identityPubkey == '\"$identityPubkey\"')' <<<$blockProduction 2>/dev/null)
@@ -53,7 +58,10 @@ delinquentValidatorInfo=$(jq -r '.validators[] | select(.voteAccountPubkey == '\
 status=2
 logentry="rootSlot=0,lastVote=0,credits=0,activatedStake=0,leaderSlots=0,skippedSlots=0,pctSkipped=0,pctTotSkipped=0,pctSkippedDelta=0,pctTotDelinquent=0,version=0,pctNewerVersions=0,commission=0,solanaPrice=$solanaPrice"
 
-if [ "$validatorInSet" -eq 0 ]; then
+if [ "$validatorInSet" -lt 0 ]; then
+   echo "unable to retrieve validator set; emitting error metrics" >&2
+   status=2
+elif [ "$validatorInSet" -eq 0 ]; then
    echo "validator not found in active set; emitting baseline metrics" >&2
    status=5
 elif [ -n "$delinquentValidatorInfo" ]; then

--- a/ansible/roles/monitoring_hub/templates/telegraf/monitor.sh.j2
+++ b/ansible/roles/monitoring_hub/templates/telegraf/monitor.sh.j2
@@ -40,110 +40,110 @@ validatorBalance=$($cli balance $identityPubkey --url $rpcURL | grep -o '[0-9.]*
 validatorVoteBalance=$($cli balance $voteAccount --url $rpcURL | grep -o '[0-9.]*')
 solanaPrice=$(curl -s 'GET' 'https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd' -H 'accept: application/json' | jq -r .solana.usd)
 openfiles=$(cat /proc/sys/fs/file-nr | awk '{ print $1 }')
-validatorCheck=$($cli validators --url $rpcURL)
+validatorCheck=$($cli validators --url $rpcURL 2>/dev/null)
+validatorInSet=$(grep -c "$voteAccount" <<< "$validatorCheck")
 
-if [ $(grep -c $voteAccount <<< $validatorCheck) == 0  ]; then echo "validator not found in set"; exit 1; fi
-    blockProduction=$($cli block-production --url $rpcURL --output json-compact 2>&- | grep -v Note:)
-    validatorBlockProduction=$(jq -r '.leaders[] | select(.identityPubkey == '\"$identityPubkey\"')' <<<$blockProduction)
-    validators=$($cli validators --url $rpcURL --output json-compact 2>&-)
-    currentValidatorInfo=$(jq -r '.validators[] | select(.voteAccountPubkey == '\"$voteAccount\"')' <<<$validators)
-    delinquentValidatorInfo=$(jq -r '.validators[] | select(.voteAccountPubkey == '\"$voteAccount\"' and .delinquent == true)' <<<$validators)
-    if [[ ((-n "$currentValidatorInfo" || "$delinquentValidatorInfo" ))  ]] || [[ ("$validatorBlockTimeTest" -eq "1" ) ]]; then
-        status=1 #status 0=validating 1=up 2=error 3=delinquent 4=stopped
-        blockHeight=$(jq -r '.slot' <<<$validatorBlockTime)
-        blockHeightTime=$(jq -r '.timestamp' <<<$validatorBlockTime)
-        if [ -n "$blockHeightTime" ]; then blockHeightFromNow=$(expr $(date +%s) - $blockHeightTime); fi
-        if [ -n "$delinquentValidatorInfo" ]; then
-              status=3
-              activatedStake=$(jq -r '.activatedStake' <<<$delinquentValidatorInfo)
-        if [ "$format" == "SOL" ]; then activatedStake=$(echo "scale=2 ; $activatedStake / 1000000000.0" | bc); fi
-              credits=$(jq -r '.credits' <<<$delinquentValidatorInfo)
-              version=$(jq -r '.version' <<<$delinquentValidatorInfo | sed 's/ /-/g')
-              version2=${version//./}
-              commission=$(jq -r '.commission' <<<$delinquentValidatorInfo)
-              logentry="rootSlot=$(jq -r '.rootSlot' <<<$delinquentValidatorInfo),lastVote=$(jq -r '.lastVote' <<<$delinquentValidatorInfo),credits=$credits,activatedStake=$activatedStake,version=$version2,commission=$commission"
-        elif [ -n "$currentValidatorInfo" ]; then
-              status=0
-              activatedStake=$(jq -r '.activatedStake' <<<$currentValidatorInfo)
-              credits=$(jq -r '.credits' <<<$currentValidatorInfo)
-              version=$(jq -r '.version' <<<$currentValidatorInfo | sed 's/ /-/g')
-              version2=${version//./}
-              commission=$(jq -r '.commission' <<<$currentValidatorInfo)
-              logentry="rootSlot=$(jq -r '.rootSlot' <<<$currentValidatorInfo),lastVote=$(jq -r '.lastVote' <<<$currentValidatorInfo)"
-              leaderSlots=$(jq -r '.leaderSlots' <<<$validatorBlockProduction)
-              leaderSlots=$(jq -r '.leaderSlots' <<<$validatorBlockProduction)
-              skippedSlots=$(jq -r '.skippedSlots' <<<$validatorBlockProduction)
-              totalBlocksProduced=$(jq -r '.total_slots' <<<$blockProduction)
-              totalSlotsSkipped=$(jq -r '.total_slots_skipped' <<<$blockProduction)
-              if [ "$format" == "SOL" ]; then activatedStake=$(echo "scale=2 ; $activatedStake / 1000000000.0" | bc); fi
-              if [ -n "$leaderSlots" ]; then pctSkipped=$(echo "scale=2 ; 100 * $skippedSlots / $leaderSlots" | bc); fi
-              if [ -z "$leaderSlots" ]; then leaderSlots=0 skippedSlots=0 pctSkipped=0; fi
-              if [ -n "$totalBlocksProduced" ]; then
-                 pctTotSkipped=$(echo "scale=2 ; 100 * $totalSlotsSkipped / $totalBlocksProduced" | bc)
-                 if [ "$pctSkipped" = 0 ] || [ "$pctTotSkipped" = 0 ]; then pctSkippedDelta=0
-                 else pctSkippedDelta=$(echo "scale=2 ; 100 * ($pctSkipped - $pctTotSkipped) / $pctTotSkipped" | bc); fi
-              fi
-              if [ -z "$pctTotSkipped" ]; then pctTotSkipped=0 pctSkippedDelta=0; fi
-              totalActiveStake=$(jq -r '.totalActiveStake' <<<$validators)
-              totalDelinquentStake=$(jq -r '.totalDelinquentStake' <<<$validators)
-              pctTotDelinquent=$(echo "scale=2 ; 100 * $totalDelinquentStake / $totalActiveStake" | bc)
-              versionActiveStake=$(jq -r '.stakeByVersion.'\"$version\"'.currentActiveStake' <<<$validators)
-              stakeByVersion=$(jq -r '.stakeByVersion' <<<$validators)
-              stakeByVersion=$(jq -r 'to_entries | map_values(.value + { version: .key })' <<<$stakeByVersion)
-              nextVersionIndex=$(expr $(jq -r 'map(.version == '\"$version\"') | index(true)' <<<$stakeByVersion) + 1)
-              stakeByVersion=$(jq '.['$nextVersionIndex':]' <<<$stakeByVersion)
-              stakeNewerVersions=$(jq -s 'map(.[].currentActiveStake) | add' <<<$stakeByVersion)
-              totalCurrentStake=$(jq -r '.totalCurrentStake' <<<$validators)
-              pctVersionActive=$(echo "scale=2 ; 100 * $versionActiveStake / $totalCurrentStake" | bc)
-              pctNewerVersions=$(echo "scale=2 ; 100 * $stakeNewerVersions / $totalCurrentStake" | bc)
-              logentry="$logentry,leaderSlots=$leaderSlots,skippedSlots=$skippedSlots,pctSkipped=$pctSkipped,pctTotSkipped=$pctTotSkipped,pctSkippedDelta=$pctSkippedDelta,pctTotDelinquent=$pctTotDelinquent"
-              logentry="$logentry,version=$version2,pctNewerVersions=$pctNewerVersions,commission=$commission,activatedStake=$activatedStake,credits=$credits,solanaPrice=$solanaPrice"
-           else status=2; fi
-        if [ "$additionalInfo" == "on" ]; then
-           nodes=$($cli gossip --url $rpcURL | grep -Po "Nodes:\s+\K[0-9]+")
-           epochInfo=$($cli epoch-info --url $rpcURL --output json-compact)
-           epoch=$(jq -r '.epoch' <<<$epochInfo)
-           tps=$(jq -r '.transactionCount' <<<$epochInfo)
-           pctEpochElapsed=$(echo "scale=2 ; 100 * $(jq -r '.slotIndex' <<<$epochInfo) / $(jq -r '.slotsInEpoch' <<<$epochInfo)" | bc)
-           validatorCreditsCurrent=$($cli vote-account $voteAccount --url $rpcURL | grep credits/max | cut -d ":" -f 2 | cut -d "/" -f 1 | awk 'NR==1{print $1}')
-           TIME=$($cli epoch-info | grep "Epoch Completed Time" | cut -d "(" -f 2 | awk '{print $1,$2,$3,$4}')
-           VAR1=$(echo $TIME | grep -oE '[0-9]+day' | grep -o -E '[0-9]+')
-           VAR2=$(echo $TIME | grep -oE '[0-9]+h'   | grep -o -E '[0-9]+')
-           VAR3=$(echo $TIME | grep -oE '[0-9]+m'   | grep -o -E '[0-9]+')
-           VAR4=$(echo $TIME | grep -oE '[0-9]+s'   | grep -o -E '[0-9]+')
-           
-           if [ -z "$VAR1" ];
-           then
-           VAR1=0
-           fi
+blockProduction=$($cli block-production --url $rpcURL --output json-compact 2>&- | grep -v Note:)
+validatorBlockProduction=$(jq -r '.leaders[] | select(.identityPubkey == '\"$identityPubkey\"')' <<<$blockProduction 2>/dev/null)
+validators=$($cli validators --url $rpcURL --output json-compact 2>&-)
+currentValidatorInfo=$(jq -r '.validators[] | select(.voteAccountPubkey == '\"$voteAccount\"')' <<<$validators 2>/dev/null)
+delinquentValidatorInfo=$(jq -r '.validators[] | select(.voteAccountPubkey == '\"$voteAccount\"' and .delinquent == true)' <<<$validators 2>/dev/null)
 
-           if [ -z "$VAR2" ];
-           then
-           VAR2=0
-           fi
+# status 0=validating 1=up 2=error 3=delinquent 4=stopped 5=not active/activating
+status=2
+logentry="rootSlot=0,lastVote=0,credits=0,activatedStake=0,leaderSlots=0,skippedSlots=0,pctSkipped=0,pctTotSkipped=0,pctSkippedDelta=0,pctTotDelinquent=0,version=0,pctNewerVersions=0,commission=0,solanaPrice=$solanaPrice"
 
-           if [ -z "$VAR3" ];
-           then
-           VAR3=0
-           fi
+if [ "$validatorInSet" -eq 0 ]; then
+   echo "validator not found in active set; emitting baseline metrics" >&2
+   status=5
+elif [ -n "$delinquentValidatorInfo" ]; then
+   status=3
+   activatedStake=$(jq -r '.activatedStake' <<<$delinquentValidatorInfo)
+   if [ "$format" == "SOL" ]; then activatedStake=$(echo "scale=2 ; $activatedStake / 1000000000.0" | bc); fi
+   credits=$(jq -r '.credits' <<<$delinquentValidatorInfo)
+   version=$(jq -r '.version' <<<$delinquentValidatorInfo | sed 's/ /-/g')
+   version2=${version//./}
+   commission=$(jq -r '.commission' <<<$delinquentValidatorInfo)
+   logentry="rootSlot=$(jq -r '.rootSlot' <<<$delinquentValidatorInfo),lastVote=$(jq -r '.lastVote' <<<$delinquentValidatorInfo),credits=$credits,activatedStake=$activatedStake,leaderSlots=0,skippedSlots=0,pctSkipped=0,pctTotSkipped=0,pctSkippedDelta=0,pctTotDelinquent=0,version=$version2,pctNewerVersions=0,commission=$commission,solanaPrice=$solanaPrice"
+elif [ -n "$currentValidatorInfo" ]; then
+   status=0
+   activatedStake=$(jq -r '.activatedStake' <<<$currentValidatorInfo)
+   credits=$(jq -r '.credits' <<<$currentValidatorInfo)
+   version=$(jq -r '.version' <<<$currentValidatorInfo | sed 's/ /-/g')
+   version2=${version//./}
+   commission=$(jq -r '.commission' <<<$currentValidatorInfo)
+   logentry="rootSlot=$(jq -r '.rootSlot' <<<$currentValidatorInfo),lastVote=$(jq -r '.lastVote' <<<$currentValidatorInfo)"
+   leaderSlots=$(jq -r '.leaderSlots // 0' <<<$validatorBlockProduction 2>/dev/null)
+   skippedSlots=$(jq -r '.skippedSlots // 0' <<<$validatorBlockProduction 2>/dev/null)
+   totalBlocksProduced=$(jq -r '.total_slots // 0' <<<$blockProduction 2>/dev/null)
+   totalSlotsSkipped=$(jq -r '.total_slots_skipped // 0' <<<$blockProduction 2>/dev/null)
+   if [ "$format" == "SOL" ]; then activatedStake=$(echo "scale=2 ; $activatedStake / 1000000000.0" | bc); fi
+   if [ "$leaderSlots" -gt 0 ] 2>/dev/null; then pctSkipped=$(echo "scale=2 ; 100 * $skippedSlots / $leaderSlots" | bc); else leaderSlots=0 skippedSlots=0 pctSkipped=0; fi
+   if [ "$totalBlocksProduced" -gt 0 ] 2>/dev/null; then
+      pctTotSkipped=$(echo "scale=2 ; 100 * $totalSlotsSkipped / $totalBlocksProduced" | bc)
+      if [ "$pctSkipped" = 0 ] || [ "$pctTotSkipped" = 0 ]; then pctSkippedDelta=0
+      else pctSkippedDelta=$(echo "scale=2 ; 100 * ($pctSkipped - $pctTotSkipped) / $pctTotSkipped" | bc); fi
+   fi
+   if [ -z "$pctTotSkipped" ]; then pctTotSkipped=0 pctSkippedDelta=0; fi
+   totalActiveStake=$(jq -r '.totalActiveStake // 0' <<<$validators)
+   totalDelinquentStake=$(jq -r '.totalDelinquentStake // 0' <<<$validators)
+   if [ "$totalActiveStake" -gt 0 ] 2>/dev/null; then pctTotDelinquent=$(echo "scale=2 ; 100 * $totalDelinquentStake / $totalActiveStake" | bc); else pctTotDelinquent=0; fi
+   versionActiveStake=$(jq -r '.stakeByVersion.'\"$version\"'.currentActiveStake // 0' <<<$validators)
+   stakeByVersion=$(jq -r '.stakeByVersion // {}' <<<$validators)
+   stakeByVersion=$(jq -r 'to_entries | map_values(.value + { version: .key })' <<<$stakeByVersion)
+   nextVersionIndex=$(expr $(jq -r 'map(.version == '\"$version\"') | index(true) // -1' <<<$stakeByVersion) + 1)
+   stakeByVersion=$(jq '.['$nextVersionIndex':]' <<<$stakeByVersion)
+   stakeNewerVersions=$(jq -s 'map(.[].currentActiveStake) | add // 0' <<<$stakeByVersion)
+   totalCurrentStake=$(jq -r '.totalCurrentStake // 0' <<<$validators)
+   if [ "$totalCurrentStake" -gt 0 ] 2>/dev/null; then pctVersionActive=$(echo "scale=2 ; 100 * $versionActiveStake / $totalCurrentStake" | bc); else pctVersionActive=0; fi
+   if [ "$totalCurrentStake" -gt 0 ] 2>/dev/null; then pctNewerVersions=$(echo "scale=2 ; 100 * $stakeNewerVersions / $totalCurrentStake" | bc); else pctNewerVersions=0; fi
+   logentry="$logentry,leaderSlots=$leaderSlots,skippedSlots=$skippedSlots,pctSkipped=$pctSkipped,pctTotSkipped=$pctTotSkipped,pctSkippedDelta=$pctSkippedDelta,pctTotDelinquent=$pctTotDelinquent"
+   logentry="$logentry,version=$version2,pctNewerVersions=$pctNewerVersions,commission=$commission,activatedStake=$activatedStake,credits=$credits,solanaPrice=$solanaPrice"
+fi
 
-           if [ -z "$VAR4" ];
-           then
-           VAR4=0
-           fi
-           
-           epochEnds=$(TZ=$timezone date -d "$VAR1 days $VAR2 hours $VAR3 minutes $VAR4 seconds" +"%m/%d/%Y %H:%M")
-           epochEnds=$(( $(TZ=$timezone date -d "$epochEnds" +%s) * 1000 ))
-           voteElapsed=$(echo "scale=4; $pctEpochElapsed / 100 * 432000" | bc)
-           if [ "$voteElapsed" = 0 ]; then pctVote=0
-           else pctVote=$(echo "scale=4; $validatorCreditsCurrent/$voteElapsed * 100" | bc); fi
-           logentry="$logentry,openFiles=$openfiles,validatorBalance=$validatorBalance,validatorVoteBalance=$validatorVoteBalance,nodes=$nodes,epoch=$epoch,pctEpochElapsed=$pctEpochElapsed,validatorCreditsCurrent=$validatorCreditsCurrent,epochEnds=$epochEnds,pctVote=$pctVote,tps=$tps"
-        fi
-        logentry="nodemonitor,pubkey=$identityPubkey status=$status,$logentry $now"
-    else
-        status=2
-        logentry="nodemonitor,pubkey=$identityPubkey status=$status $now"
-    fi
+if [ "$additionalInfo" == "on" ]; then
+   nodes=$($cli gossip --url $rpcURL | grep -Po "Nodes:\s+\K[0-9]+")
+   epochInfo=$($cli epoch-info --url $rpcURL --output json-compact)
+   epoch=$(jq -r '.epoch' <<<$epochInfo)
+   tps=$(jq -r '.transactionCount' <<<$epochInfo)
+   pctEpochElapsed=$(echo "scale=2 ; 100 * $(jq -r '.slotIndex' <<<$epochInfo) / $(jq -r '.slotsInEpoch' <<<$epochInfo)" | bc)
+   validatorCreditsCurrent=$($cli vote-account $voteAccount --url $rpcURL | grep credits/max | cut -d ":" -f 2 | cut -d "/" -f 1 | awk 'NR==1{print $1}')
+   validatorCreditsCurrent=${validatorCreditsCurrent:-0}
+   TIME=$($cli epoch-info --url $rpcURL | grep "Epoch Completed Time" | cut -d "(" -f 2 | awk '{print $1,$2,$3,$4}')
+   VAR1=$(echo $TIME | grep -oE '[0-9]+day' | grep -o -E '[0-9]+')
+   VAR2=$(echo $TIME | grep -oE '[0-9]+h'   | grep -o -E '[0-9]+')
+   VAR3=$(echo $TIME | grep -oE '[0-9]+m'   | grep -o -E '[0-9]+')
+   VAR4=$(echo $TIME | grep -oE '[0-9]+s'   | grep -o -E '[0-9]+')
+
+   if [ -z "$VAR1" ];
+   then
+   VAR1=0
+   fi
+
+   if [ -z "$VAR2" ];
+   then
+   VAR2=0
+   fi
+
+   if [ -z "$VAR3" ];
+   then
+   VAR3=0
+   fi
+
+   if [ -z "$VAR4" ];
+   then
+   VAR4=0
+   fi
+
+   epochEnds=$(TZ=$timezone date -d "$VAR1 days $VAR2 hours $VAR3 minutes $VAR4 seconds" +"%m/%d/%Y %H:%M")
+   epochEnds=$(( $(TZ=$timezone date -d "$epochEnds" +%s) * 1000 ))
+   voteElapsed=$(echo "scale=4; $pctEpochElapsed / 100 * 432000" | bc)
+   if [ "$voteElapsed" = 0 ]; then pctVote=0
+   else pctVote=$(echo "scale=4; $validatorCreditsCurrent/$voteElapsed * 100" | bc); fi
+   logentry="$logentry,openFiles=$openfiles,validatorBalance=$validatorBalance,validatorVoteBalance=$validatorVoteBalance,nodes=$nodes,epoch=$epoch,pctEpochElapsed=$pctEpochElapsed,validatorCreditsCurrent=$validatorCreditsCurrent,epochEnds=$epochEnds,pctVote=$pctVote,tps=$tps"
+fi
+
+logentry="nodemonitor,pubkey=$identityPubkey status=$status,$logentry $now"
 
 # Defensive cleanup: avoid invalid line protocol from empty/null numeric fields,
 # bare decimal values (e.g. .36 -> 0.36), negative bare decimals (e.g. -.92 -> -0.92),


### PR DESCRIPTION
# Pull Request Template

## 📝 Summary

Adds XDP status visibility to the hardware metrics dashboard and makes the validator metrics template path more resilient when a validator is configured but not currently active in the validator set.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🚀 Performance improvement
- [ ] ♻️ Code refactoring (no functional changes)

## 🔍 Scope & Complexity

**Please keep PRs focused and small for faster reviews.**

- [x] This PR changes **fewer than 400 lines** of code (excluding generated/dashboard JSON)
- [x] This PR addresses **only one logical change** or feature
- [x] This PR can be **reviewed in under 30 minutes**
- [ ] This PR does **not mix multiple types of changes** (e.g., refactoring + new features)

If any of the above are unchecked, consider breaking this PR into smaller, focused changes.

## 📋 Changes Made

Detailed list of changes:

- Adds human-readable XDP status panels to the Hardware Metrics dashboard for health, enabled state, runtime flags, and attach status.
- Adds an XDP details table for host/interface state, alert flags, and diagnostic reasons.
- Extends the per-network monitoring template deploy playbook so validator and hardware dashboard templates can be imported without rerunning the full monitoring hub role.
- Makes the validator monitor script continue emitting baseline `nodemonitor` data when the vote account is not present in the active validator set.
- Adds an explicit validator status mapping for the configured-but-not-active case.

## 🧪 Testing

- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Manual testing completed
- [x] Existing functionality verified unchanged
- [ ] Documentation updated (if applicable)

### Test Details

- Ran `jq empty ansible/roles/monitoring_hub/templates/grafana/hardware_metrics.json`.
- Ran `git diff --check`.
- Ran `ansible-playbook playbooks/pb_deploy_monitoring_templates_per_network.yml --syntax-check -e target_host=localhost -e target_network=mainnet`.
- Deployed the updated monitoring templates to the live monitoring host.
- Confirmed the Hardware Metrics dashboard shows XDP status for hosts emitting `xdp_status`.
- Confirmed the Validator Metrics dashboard keeps useful baseline data when the configured validator is not active yet.

## 📚 Documentation

- [ ] Updated relevant documentation
- [ ] Added/updated comments for complex logic
- [ ] README updated (if applicable)
- [x] No documentation changes needed

## 🔗 Related Issues

N/A

## 📝 Review Notes

The largest part of this diff is Grafana dashboard JSON. The most useful review path is to verify the live dashboards visually and focus code review on the monitor script behavior plus the template deploy playbook.

The dashboard JSON is intentionally included here because the expected operator-facing result is visible in Grafana: XDP health, enabled state, runtime flags, and attach state are now shown per selected host.

---

## For Reviewers

**Estimated review time:** ⏱️ 20 minutes

**Focus areas:**
- [x] Logic correctness
- [x] Security implications
- [ ] Performance impact
- [ ] Documentation completeness
