### PR TITLE
Persist XDP NIC Ring Settings

### DIFF
--- a/ansible/playbooks/pb_setup_validator_agave.yml
+++ b/ansible/playbooks/pb_setup_validator_agave.yml
@@ -41,6 +41,9 @@
 # - force_host_cleanup (OPTIONAL): Cleanup target host if it has validator data from a different cluster.
 # - run_poh_cpu_affinity_fix (OPTIONAL): Pin validator process to specific CPU core to improve PoH stability.
 # - xdp_enabled (OPTIONAL): Enable or disable XDP flag injection in validator startup script (default is disabled).
+# - xdp_ring_config_enabled (OPTIONAL): Persist XDP NIC ring sizing before validator startup (default is disabled).
+# - xdp_ring_rx / xdp_ring_tx (OPTIONAL): RX/TX ring sizes used when xdp_ring_config_enabled=true (default 4096/4096).
+# - xdp_ring_interface (OPTIONAL): Interface override for ring sizing; defaults to the resolved XDP interface.
 
 - name: Install Agave Validator
   hosts: "{{ target_host }}"

--- a/ansible/playbooks/pb_setup_validator_jito_v2.yml
+++ b/ansible/playbooks/pb_setup_validator_jito_v2.yml
@@ -57,6 +57,9 @@
 # - force_host_cleanup (OPTIONAL): Cleanup target host if it has validator data from a different cluster.
 # - run_poh_cpu_affinity_fix (OPTIONAL): Pin validator process to specific CPU core to improve PoH stability.
 # - xdp_enabled (OPTIONAL): Enable or disable XDP flag injection in validator startup script (default is disabled).
+# - xdp_ring_config_enabled (OPTIONAL): Persist XDP NIC ring sizing before validator startup (default is disabled).
+# - xdp_ring_rx / xdp_ring_tx (OPTIONAL): RX/TX ring sizes used when xdp_ring_config_enabled=true (default 4096/4096).
+# - xdp_ring_interface (OPTIONAL): Interface override for ring sizing; defaults to the resolved XDP interface.
 
 - name: Install Jito Client with BAM
   hosts: "{{ target_host }}"

--- a/ansible/roles/solana_validator_agave/meta/argument_specs.yml
+++ b/ansible/roles/solana_validator_agave/meta/argument_specs.yml
@@ -62,6 +62,26 @@ argument_specs:
         required: false
         default: true
         description: "Run shared NUMA placement assessment between XDP retransmit cores and PoH pinned core"
+      xdp_ring_config_enabled:
+        type: bool
+        required: false
+        default: false
+        description: "Persist NIC RX/TX ring sizes with a systemd unit ordered before the validator service"
+      xdp_ring_interface:
+        type: str
+        required: false
+        default: ""
+        description: "Optional interface override for persistent XDP ring sizing; defaults to the selected XDP interface"
+      xdp_ring_rx:
+        type: int
+        required: false
+        default: 4096
+        description: "Requested RX ring size when xdp_ring_config_enabled is true"
+      xdp_ring_tx:
+        type: int
+        required: false
+        default: 4096
+        description: "Requested TX ring size when xdp_ring_config_enabled is true"
       solana_validator_ha_install_enabled:
         type: bool
         required: false

--- a/ansible/roles/solana_validator_agave/meta/argument_specs.yml
+++ b/ansible/roles/solana_validator_agave/meta/argument_specs.yml
@@ -27,6 +27,15 @@ argument_specs:
         required: true
         choices: ["localnet", "testnet", "mainnet"]
         description: "Target Solana cluster"
+      expected_shred_version:
+        type: int
+        required: false
+        description: "Expected cluster shred version rendered as --expected-shred-version. Required when XDP zero-copy is effectively enabled unless expected_shred_version_auto_detect is true."
+      expected_shred_version_auto_detect:
+        type: bool
+        required: false
+        default: false
+        description: "When true and expected_shred_version is unset, query the configured RPC URL and use the majority non-zero cluster shredVersion."
       force_host_cleanup:
         type: bool
         required: false

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -60,6 +60,69 @@
             known_validators: "{{ known_validators + [entrypoint_identity_cmd.stdout] }}"
       when: solana_cluster == "localnet"
 
+    - name: configure - Auto-detect expected shred version
+      block:
+        - name: configure - Query cluster shred versions
+          ansible.builtin.shell: |
+            set -euo pipefail
+            python3 - <<'PY'
+            import json
+            import sys
+            import urllib.request
+
+            rpc_url = {{ (solana_rpc_url | default('')) | to_json }}
+            payload = json.dumps({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getClusterNodes",
+            }).encode("utf-8")
+            request = urllib.request.Request(
+                rpc_url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=20) as response:
+                body = json.load(response)
+            nodes = body.get("result", [])
+            versions = {}
+            for node in nodes:
+                version = int(node.get("shredVersion") or 0)
+                if version > 0:
+                    versions[version] = versions.get(version, 0) + 1
+            if not versions:
+                print("No non-zero shredVersion values returned", file=sys.stderr)
+                sys.exit(1)
+            version, count = sorted(versions.items(), key=lambda item: (-item[1], item[0]))[0]
+            print(f"{version} {count}")
+            PY
+          args:
+            executable: /bin/bash
+          register: cluster_shred_version_cmd
+          delegate_to: localhost
+          changed_when: false
+
+        - name: configure - Set expected shred version
+          ansible.builtin.set_fact:
+            expected_shred_version: "{{ cluster_shred_version_cmd.stdout.split()[0] }}"
+            expected_shred_version_observed_count: "{{ cluster_shred_version_cmd.stdout.split()[1] }}"
+      when:
+        - expected_shred_version_auto_detect | default(false) | bool
+        - (expected_shred_version | default('') | string | trim | length) == 0
+        - solana_cluster != "localnet"
+
+    - name: configure - Require expected shred version when XDP zero-copy is enabled
+      ansible.builtin.assert:
+        that:
+          - (expected_shred_version | default('') | string | trim | length) > 0
+        fail_msg: >-
+          xdp_experimental_retransmit_xdp_zero_copy resolved to an effective startup flag, but
+          expected_shred_version is unset. Set expected_shred_version explicitly or enable
+          expected_shred_version_auto_detect=true.
+      when:
+        - xdp_zero_copy_effective | default(false) | bool
+        - solana_cluster != "localnet"
+
     - name: configure - Create validator startup script
       ansible.builtin.template:
         src: validator.startup.j2

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -20,7 +20,11 @@
 
 - name: configure - Compute XDP runtime flags
   ansible.builtin.import_tasks: ../../solana_validator_shared/tasks/configure_xdp.yml
-  tags: [xdp, xdp_preflight, xdp_config]
+  tags: [xdp, xdp_ring, xdp_preflight, xdp_config]
+
+- name: configure - Configure persistent XDP NIC rings
+  ansible.builtin.import_tasks: ../../solana_validator_shared/tasks/configure_xdp_ring.yml
+  tags: [xdp, xdp_ring, xdp_config]
 
 - name: configure - Configure validator startup script
   block:

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -108,18 +108,18 @@
             expected_shred_version_observed_count: "{{ cluster_shred_version_cmd.stdout.split()[1] }}"
       when:
         - expected_shred_version_auto_detect | default(false) | bool
-        - (expected_shred_version | default('') | string | trim | length) == 0
+        - (expected_shred_version | default(0) | int) <= 0
         - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"
 
     - name: configure - Require expected shred version when XDP zero-copy is enabled
       ansible.builtin.assert:
         that:
-          - (expected_shred_version | default('') | string | trim | length) > 0
+          - (expected_shred_version | default(0) | int) > 0
         fail_msg: >-
           xdp_experimental_retransmit_xdp_zero_copy resolved to an effective startup flag, but
-          expected_shred_version is unset. Set expected_shred_version explicitly or enable
-          expected_shred_version_auto_detect=true.
+          expected_shred_version is not a positive integer. Set expected_shred_version explicitly
+          or enable expected_shred_version_auto_detect=true.
       when:
         - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"

--- a/ansible/roles/solana_validator_agave/tasks/configure.yml
+++ b/ansible/roles/solana_validator_agave/tasks/configure.yml
@@ -109,6 +109,7 @@
       when:
         - expected_shred_version_auto_detect | default(false) | bool
         - (expected_shred_version | default('') | string | trim | length) == 0
+        - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"
 
     - name: configure - Require expected shred version when XDP zero-copy is enabled
@@ -120,7 +121,7 @@
           expected_shred_version is unset. Set expected_shred_version explicitly or enable
           expected_shred_version_auto_detect=true.
       when:
-        - xdp_zero_copy_effective | default(false) | bool
+        - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"
 
     - name: configure - Create validator startup script

--- a/ansible/roles/solana_validator_agave/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.startup.j2
@@ -32,8 +32,11 @@ exec agave-validator \
 --entrypoint {{ entrypoint }} \
 {% endfor %}
 --expected-genesis-hash {{ expected_genesis_hash }} \
+{% if expected_shred_version is defined and (expected_shred_version | string | trim | length) > 0 %}
+--expected-shred-version {{ expected_shred_version }} \
+{% endif %}
 --wal-recovery-mode skip_any_corrupted_record \
---limit-ledger-size {{ limit_ledger_size | default('') }} \
+--limit-ledger-size{% if limit_ledger_size is defined and (limit_ledger_size | string | trim | length) > 0 %} {{ limit_ledger_size }}{% endif %} \
 --block-verification-method unified-scheduler \
 {% if solana_cluster != "localnet" and poh_pinned_cpu_core_enabled is defined and poh_pinned_cpu_core_enabled and poh_pinned_cpu_core is defined %}
 --experimental-poh-pinned-cpu-core {{ poh_pinned_cpu_core }} \

--- a/ansible/roles/solana_validator_agave/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_agave/templates/validator.startup.j2
@@ -32,7 +32,7 @@ exec agave-validator \
 --entrypoint {{ entrypoint }} \
 {% endfor %}
 --expected-genesis-hash {{ expected_genesis_hash }} \
-{% if expected_shred_version is defined and (expected_shred_version | string | trim | length) > 0 %}
+{% if expected_shred_version is defined and (expected_shred_version | int) > 0 %}
 --expected-shred-version {{ expected_shred_version }} \
 {% endif %}
 --wal-recovery-mode skip_any_corrupted_record \

--- a/ansible/roles/solana_validator_jito_v2/meta/argument_specs.yml
+++ b/ansible/roles/solana_validator_jito_v2/meta/argument_specs.yml
@@ -63,6 +63,26 @@ argument_specs:
         required: false
         default: true
         description: "Run shared NUMA placement assessment between XDP retransmit cores and PoH pinned core"
+      xdp_ring_config_enabled:
+        type: bool
+        required: false
+        default: false
+        description: "Persist NIC RX/TX ring sizes with a systemd unit ordered before the validator service"
+      xdp_ring_interface:
+        type: str
+        required: false
+        default: ""
+        description: "Optional interface override for persistent XDP ring sizing; defaults to the selected XDP interface"
+      xdp_ring_rx:
+        type: int
+        required: false
+        default: 4096
+        description: "Requested RX ring size when xdp_ring_config_enabled is true"
+      xdp_ring_tx:
+        type: int
+        required: false
+        default: 4096
+        description: "Requested TX ring size when xdp_ring_config_enabled is true"
       solana_validator_ha_install_enabled:
         type: bool
         required: false

--- a/ansible/roles/solana_validator_jito_v2/meta/argument_specs.yml
+++ b/ansible/roles/solana_validator_jito_v2/meta/argument_specs.yml
@@ -28,6 +28,15 @@ argument_specs:
         required: true
         choices: ["localnet", "testnet", "mainnet"]
         description: "Target Solana cluster"
+      expected_shred_version:
+        type: int
+        required: false
+        description: "Expected cluster shred version rendered as --expected-shred-version. Required when XDP zero-copy is effectively enabled unless expected_shred_version_auto_detect is true."
+      expected_shred_version_auto_detect:
+        type: bool
+        required: false
+        default: false
+        description: "When true and expected_shred_version is unset, query the configured RPC URL and use the majority non-zero cluster shredVersion."
       force_host_cleanup:
         type: bool
         required: false

--- a/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
@@ -112,6 +112,7 @@
       when:
         - expected_shred_version_auto_detect | default(false) | bool
         - (expected_shred_version | default('') | string | trim | length) == 0
+        - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"
 
     - name: configure - Require expected shred version when XDP zero-copy is enabled
@@ -123,7 +124,7 @@
           expected_shred_version is unset. Set expected_shred_version explicitly or enable
           expected_shred_version_auto_detect=true.
       when:
-        - xdp_zero_copy_effective | default(false) | bool
+        - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"
 
     - name: configure - Create validator startup script

--- a/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
@@ -63,6 +63,69 @@
             known_validators: "{{ known_validators + [entrypoint_identity_cmd.stdout] }}"
       when: solana_cluster == "localnet"
 
+    - name: configure - Auto-detect expected shred version
+      block:
+        - name: configure - Query cluster shred versions
+          ansible.builtin.shell: |
+            set -euo pipefail
+            python3 - <<'PY'
+            import json
+            import sys
+            import urllib.request
+
+            rpc_url = {{ (solana_rpc_url | default('')) | to_json }}
+            payload = json.dumps({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getClusterNodes",
+            }).encode("utf-8")
+            request = urllib.request.Request(
+                rpc_url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=20) as response:
+                body = json.load(response)
+            nodes = body.get("result", [])
+            versions = {}
+            for node in nodes:
+                version = int(node.get("shredVersion") or 0)
+                if version > 0:
+                    versions[version] = versions.get(version, 0) + 1
+            if not versions:
+                print("No non-zero shredVersion values returned", file=sys.stderr)
+                sys.exit(1)
+            version, count = sorted(versions.items(), key=lambda item: (-item[1], item[0]))[0]
+            print(f"{version} {count}")
+            PY
+          args:
+            executable: /bin/bash
+          register: cluster_shred_version_cmd
+          delegate_to: localhost
+          changed_when: false
+
+        - name: configure - Set expected shred version
+          ansible.builtin.set_fact:
+            expected_shred_version: "{{ cluster_shred_version_cmd.stdout.split()[0] }}"
+            expected_shred_version_observed_count: "{{ cluster_shred_version_cmd.stdout.split()[1] }}"
+      when:
+        - expected_shred_version_auto_detect | default(false) | bool
+        - (expected_shred_version | default('') | string | trim | length) == 0
+        - solana_cluster != "localnet"
+
+    - name: configure - Require expected shred version when XDP zero-copy is enabled
+      ansible.builtin.assert:
+        that:
+          - (expected_shred_version | default('') | string | trim | length) > 0
+        fail_msg: >-
+          xdp_experimental_retransmit_xdp_zero_copy resolved to an effective startup flag, but
+          expected_shred_version is unset. Set expected_shred_version explicitly or enable
+          expected_shred_version_auto_detect=true.
+      when:
+        - xdp_zero_copy_effective | default(false) | bool
+        - solana_cluster != "localnet"
+
     - name: configure - Create validator startup script
       ansible.builtin.template:
         src: validator.startup.j2

--- a/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
@@ -20,7 +20,11 @@
 
 - name: configure - Compute XDP runtime flags
   ansible.builtin.import_tasks: ../../solana_validator_shared/tasks/configure_xdp.yml
-  tags: [xdp, xdp_preflight, xdp_config]
+  tags: [xdp, xdp_ring, xdp_preflight, xdp_config]
+
+- name: configure - Configure persistent XDP NIC rings
+  ansible.builtin.import_tasks: ../../solana_validator_shared/tasks/configure_xdp_ring.yml
+  tags: [xdp, xdp_ring, xdp_config]
 
 - name: configure - Configure validator startup script
   block:

--- a/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
+++ b/ansible/roles/solana_validator_jito_v2/tasks/configure.yml
@@ -111,18 +111,18 @@
             expected_shred_version_observed_count: "{{ cluster_shred_version_cmd.stdout.split()[1] }}"
       when:
         - expected_shred_version_auto_detect | default(false) | bool
-        - (expected_shred_version | default('') | string | trim | length) == 0
+        - (expected_shred_version | default(0) | int) <= 0
         - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"
 
     - name: configure - Require expected shred version when XDP zero-copy is enabled
       ansible.builtin.assert:
         that:
-          - (expected_shred_version | default('') | string | trim | length) > 0
+          - (expected_shred_version | default(0) | int) > 0
         fail_msg: >-
           xdp_experimental_retransmit_xdp_zero_copy resolved to an effective startup flag, but
-          expected_shred_version is unset. Set expected_shred_version explicitly or enable
-          expected_shred_version_auto_detect=true.
+          expected_shred_version is not a positive integer. Set expected_shred_version explicitly
+          or enable expected_shred_version_auto_detect=true.
       when:
         - xdp_zero_copy_startup_enabled | default(false) | bool
         - solana_cluster != "localnet"

--- a/ansible/roles/solana_validator_jito_v2/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_jito_v2/templates/validator.startup.j2
@@ -32,8 +32,11 @@ exec agave-validator \
 --entrypoint {{ entrypoint }} \
 {% endfor %}
 --expected-genesis-hash {{ expected_genesis_hash }} \
+{% if expected_shred_version is defined and (expected_shred_version | string | trim | length) > 0 %}
+--expected-shred-version {{ expected_shred_version }} \
+{% endif %}
 --wal-recovery-mode skip_any_corrupted_record \
---limit-ledger-size {{ limit_ledger_size | default('') }} \
+--limit-ledger-size{% if limit_ledger_size is defined and (limit_ledger_size | string | trim | length) > 0 %} {{ limit_ledger_size }}{% endif %} \
 --block-verification-method unified-scheduler \
 {% if solana_cluster != "localnet" and poh_pinned_cpu_core_enabled is defined and poh_pinned_cpu_core_enabled and poh_pinned_cpu_core is defined %}
 --experimental-poh-pinned-cpu-core {{ poh_pinned_cpu_core }} \

--- a/ansible/roles/solana_validator_jito_v2/templates/validator.startup.j2
+++ b/ansible/roles/solana_validator_jito_v2/templates/validator.startup.j2
@@ -32,7 +32,7 @@ exec agave-validator \
 --entrypoint {{ entrypoint }} \
 {% endfor %}
 --expected-genesis-hash {{ expected_genesis_hash }} \
-{% if expected_shred_version is defined and (expected_shred_version | string | trim | length) > 0 %}
+{% if expected_shred_version is defined and (expected_shred_version | int) > 0 %}
 --expected-shred-version {{ expected_shred_version }} \
 {% endif %}
 --wal-recovery-mode skip_any_corrupted_record \

--- a/ansible/roles/solana_validator_shared/defaults/main.yml
+++ b/ansible/roles/solana_validator_shared/defaults/main.yml
@@ -10,6 +10,10 @@ xdp_min_supported_version: "3.0.9"
 xdp_min_kernel_version: "5.10.0"
 xdp_numa_check_enabled: true
 xdp_runtime_state_file_path: "{{ validator_root_dir }}/xdp_status.env"
+xdp_ring_config_enabled: false
+xdp_ring_interface: ""
+xdp_ring_rx: 4096
+xdp_ring_tx: 4096
 identity_duplicate_check_timeout_seconds: 45
 identity_duplicate_check_retry_attempts: 3
 identity_duplicate_check_retry_delay_seconds: 2
@@ -17,4 +21,3 @@ xdp_unsupported_iface_drivers:
   - "virtio_net"
 xdp_zero_copy_unsupported_iface_drivers:
   - "bnxt_en"
-  - "i40e"

--- a/ansible/roles/solana_validator_shared/tasks/configure_xdp.yml
+++ b/ansible/roles/solana_validator_shared/tasks/configure_xdp.yml
@@ -941,6 +941,10 @@
         xdp_effective_enabled: "{{ (xdp_skip_reasons | length == 0) and (xdp_params | length > 0) }}"
         xdp_skip_reason: "{{ (xdp_skip_reasons | first) if (xdp_skip_reasons | length > 0) else '' }}"
 
+    - name: xdp - Derive zero-copy startup status from params
+      ansible.builtin.set_fact:
+        xdp_zero_copy_startup_enabled: "{{ (xdp_effective_enabled | bool) and ('--experimental-retransmit-xdp-zero-copy' in (xdp_params | default([]))) }}"
+
     - name: xdp - Merge XDP params into extra_params
       ansible.builtin.set_fact:
         extra_params: "{{ (extra_params | default([])) + xdp_params }}"

--- a/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
+++ b/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
@@ -4,6 +4,40 @@
     xdp_ring_effective_interface: "{{ (xdp_ring_interface | default('') | trim) if ((xdp_ring_interface | default('') | trim | length) > 0) else (xdp_primary_iface | default('') | trim) }}"
   when: xdp_ring_config_enabled | default(false) | bool
 
+- name: xdp_ring - Check persistent systemd unit when disabled
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/xdp-rings-{{ validator_service_name }}.service"
+  register: xdp_ring_unit_stat
+  when: not (xdp_ring_config_enabled | default(false) | bool)
+
+- name: xdp_ring - Disable persistent systemd unit when disabled
+  ansible.builtin.systemd:
+    name: "xdp-rings-{{ validator_service_name }}.service"
+    enabled: false
+    state: stopped
+  when:
+    - not (xdp_ring_config_enabled | default(false) | bool)
+    - xdp_ring_unit_stat.stat.exists | default(false)
+  become: true
+
+- name: xdp_ring - Remove persistent systemd unit when disabled
+  ansible.builtin.file:
+    path: "/etc/systemd/system/xdp-rings-{{ validator_service_name }}.service"
+    state: absent
+  register: xdp_ring_unit_remove_result
+  when:
+    - not (xdp_ring_config_enabled | default(false) | bool)
+    - xdp_ring_unit_stat.stat.exists | default(false)
+  become: true
+
+- name: xdp_ring - Reload systemd after removing disabled unit
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when:
+    - not (xdp_ring_config_enabled | default(false) | bool)
+    - xdp_ring_unit_remove_result.changed | default(false)
+  become: true
+
 - name: xdp_ring - Validate requested ring settings
   ansible.builtin.assert:
     that:

--- a/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
+++ b/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
@@ -83,18 +83,6 @@
   failed_when: false
   when: xdp_ring_config_enabled | default(false) | bool
 
-- name: xdp_ring - Refuse live ring change while validator is running
-  ansible.builtin.assert:
-    that:
-      - xdp_ring_validator_active_cmd.rc != 0
-    fail_msg: >-
-      {{ validator_service_name }} is active and {{ xdp_ring_effective_interface }} rings are
-      {{ xdp_ring_current_rx }}/{{ xdp_ring_current_tx }}, not {{ xdp_ring_rx }}/{{ xdp_ring_tx }}.
-      Stop the validator or reboot into a maintenance window before applying ring changes.
-  when:
-    - xdp_ring_config_enabled | default(false) | bool
-    - xdp_ring_update_required | default(false) | bool
-
 - name: xdp_ring - Install persistent systemd unit
   ansible.builtin.copy:
     dest: "/etc/systemd/system/xdp-rings-{{ validator_service_name }}.service"
@@ -114,8 +102,19 @@
       RemainAfterExit=yes
 
       [Install]
-      WantedBy=multi-user.target
+      WantedBy={{ validator_service_name }}.service
+  register: xdp_ring_unit_copy_result
   when: xdp_ring_config_enabled | default(false) | bool
+  become: true
+
+- name: xdp_ring - Reset persistent systemd unit install links when changed
+  ansible.builtin.systemd:
+    name: "xdp-rings-{{ validator_service_name }}.service"
+    enabled: false
+    daemon_reload: true
+  when:
+    - xdp_ring_config_enabled | default(false) | bool
+    - xdp_ring_unit_copy_result.changed | default(false)
   become: true
 
 - name: xdp_ring - Enable persistent systemd unit
@@ -125,6 +124,27 @@
     daemon_reload: true
   when: xdp_ring_config_enabled | default(false) | bool
   become: true
+
+- name: xdp_ring - Mark staged ring unit pending while validator is running
+  ansible.builtin.systemd:
+    name: "xdp-rings-{{ validator_service_name }}.service"
+    state: stopped
+  when:
+    - xdp_ring_config_enabled | default(false) | bool
+    - xdp_ring_update_required | default(false) | bool
+    - xdp_ring_validator_active_cmd.rc == 0
+  become: true
+
+- name: xdp_ring - Report staged ring change while validator is running
+  ansible.builtin.debug:
+    msg: >-
+      {{ validator_service_name }} is active and {{ xdp_ring_effective_interface }} rings are
+      {{ xdp_ring_current_rx }}/{{ xdp_ring_current_tx }}, not {{ xdp_ring_rx }}/{{ xdp_ring_tx }}.
+      The xdp-rings unit has been staged and will apply before the next {{ validator_service_name }} start.
+  when:
+    - xdp_ring_config_enabled | default(false) | bool
+    - xdp_ring_update_required | default(false) | bool
+    - xdp_ring_validator_active_cmd.rc == 0
 
 - name: xdp_ring - Apply rings now when validator is stopped
   ansible.builtin.systemd:

--- a/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
+++ b/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
@@ -1,0 +1,97 @@
+---
+- name: xdp_ring - Select interface
+  ansible.builtin.set_fact:
+    xdp_ring_effective_interface: "{{ (xdp_ring_interface | default('') | trim) if ((xdp_ring_interface | default('') | trim | length) > 0) else (xdp_primary_iface | default('') | trim) }}"
+  when: xdp_ring_config_enabled | default(false) | bool
+
+- name: xdp_ring - Validate requested ring settings
+  ansible.builtin.assert:
+    that:
+      - xdp_ring_effective_interface | length > 0
+      - xdp_ring_rx | int > 0
+      - xdp_ring_tx | int > 0
+      - (xdp_ring_rx | int) in [64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+      - (xdp_ring_tx | int) in [64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+    fail_msg: "xdp_ring_config_enabled requires a resolved interface and power-of-two rx/tx ring sizes."
+  when: xdp_ring_config_enabled | default(false) | bool
+
+- name: xdp_ring - Read current ring settings
+  ansible.builtin.shell: |
+    set -o pipefail
+    ethtool -g {{ xdp_ring_effective_interface | quote }} \
+      | awk '
+        /Current hardware settings:/ {current=1}
+        current && /^RX:/ {print "rx="$2}
+        current && /^TX:/ {print "tx="$2}
+      '
+  register: xdp_ring_current_cmd
+  changed_when: false
+  when: xdp_ring_config_enabled | default(false) | bool
+  args:
+    executable: /bin/bash
+  become: true
+
+- name: xdp_ring - Set current ring facts
+  ansible.builtin.set_fact:
+    xdp_ring_current_rx: "{{ xdp_ring_current_cmd.stdout | regex_findall('(?m)^rx=(\\d+)$') | first | default('') }}"
+    xdp_ring_current_tx: "{{ xdp_ring_current_cmd.stdout | regex_findall('(?m)^tx=(\\d+)$') | first | default('') }}"
+  when: xdp_ring_config_enabled | default(false) | bool
+
+- name: xdp_ring - Check validator service state
+  ansible.builtin.command: "systemctl is-active {{ validator_service_name }}"
+  register: xdp_ring_validator_active_cmd
+  changed_when: false
+  failed_when: false
+  when: xdp_ring_config_enabled | default(false) | bool
+
+- name: xdp_ring - Refuse live ring change while validator is running
+  ansible.builtin.assert:
+    that:
+      - xdp_ring_validator_active_cmd.rc != 0
+    fail_msg: >-
+      {{ validator_service_name }} is active and {{ xdp_ring_effective_interface }} rings are
+      {{ xdp_ring_current_rx }}/{{ xdp_ring_current_tx }}, not {{ xdp_ring_rx }}/{{ xdp_ring_tx }}.
+      Stop the validator or reboot into a maintenance window before applying ring changes.
+  when:
+    - xdp_ring_config_enabled | default(false) | bool
+    - (xdp_ring_current_rx | string) != (xdp_ring_rx | string) or (xdp_ring_current_tx | string) != (xdp_ring_tx | string)
+
+- name: xdp_ring - Install persistent systemd unit
+  ansible.builtin.copy:
+    dest: "/etc/systemd/system/xdp-rings-{{ validator_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Configure XDP NIC rings for {{ validator_service_name }}
+      Documentation=man:ethtool(8)
+      After=network-pre.target systemd-udev-settle.service
+      Before={{ validator_service_name }}.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/sbin/ethtool -G {{ xdp_ring_effective_interface }} rx {{ xdp_ring_rx | int }} tx {{ xdp_ring_tx | int }}
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+  when: xdp_ring_config_enabled | default(false) | bool
+  become: true
+
+- name: xdp_ring - Enable persistent systemd unit
+  ansible.builtin.systemd:
+    name: "xdp-rings-{{ validator_service_name }}.service"
+    enabled: true
+    daemon_reload: true
+  when: xdp_ring_config_enabled | default(false) | bool
+  become: true
+
+- name: xdp_ring - Apply rings now when validator is stopped
+  ansible.builtin.systemd:
+    name: "xdp-rings-{{ validator_service_name }}.service"
+    state: started
+  when:
+    - xdp_ring_config_enabled | default(false) | bool
+    - xdp_ring_validator_active_cmd.rc != 0
+  become: true

--- a/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
+++ b/ansible/roles/solana_validator_shared/tasks/configure_xdp_ring.yml
@@ -37,6 +37,11 @@
     xdp_ring_current_tx: "{{ xdp_ring_current_cmd.stdout | regex_findall('(?m)^tx=(\\d+)$') | first | default('') }}"
   when: xdp_ring_config_enabled | default(false) | bool
 
+- name: xdp_ring - Set update requirement fact
+  ansible.builtin.set_fact:
+    xdp_ring_update_required: "{{ (xdp_ring_current_rx | string) != (xdp_ring_rx | string) or (xdp_ring_current_tx | string) != (xdp_ring_tx | string) }}"
+  when: xdp_ring_config_enabled | default(false) | bool
+
 - name: xdp_ring - Check validator service state
   ansible.builtin.command: "systemctl is-active {{ validator_service_name }}"
   register: xdp_ring_validator_active_cmd
@@ -54,7 +59,7 @@
       Stop the validator or reboot into a maintenance window before applying ring changes.
   when:
     - xdp_ring_config_enabled | default(false) | bool
-    - (xdp_ring_current_rx | string) != (xdp_ring_rx | string) or (xdp_ring_current_tx | string) != (xdp_ring_tx | string)
+    - xdp_ring_update_required | default(false) | bool
 
 - name: xdp_ring - Install persistent systemd unit
   ansible.builtin.copy:
@@ -90,7 +95,7 @@
 - name: xdp_ring - Apply rings now when validator is stopped
   ansible.builtin.systemd:
     name: "xdp-rings-{{ validator_service_name }}.service"
-    state: started
+    state: "{{ (xdp_ring_update_required | default(false) | bool) | ternary('restarted', 'started') }}"
   when:
     - xdp_ring_config_enabled | default(false) | bool
     - xdp_ring_validator_active_cmd.rc != 0


### PR DESCRIPTION
# Pull Request Template

## 📝 Summary

Persists optional XDP NIC ring sizing before validator startup and requires an expected shred version whenever XDP zero-copy is enabled for non-localnet validators.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🚀 Performance improvement
- [ ] ♻️ Code refactoring (no functional changes)

## 🔍 Scope & Complexity

**Please keep PRs focused and small for faster reviews.**

- [x] This PR changes **fewer than 400 lines** of code (excluding generated files)
- [x] This PR addresses **only one logical change** or feature
- [x] This PR can be **reviewed in under 30 minutes**
- [x] This PR does **not mix multiple types of changes** (e.g., refactoring + new features)

If any of the above are unchecked, consider breaking this PR into smaller, focused changes.

## 📋 Changes Made

Detailed list of changes:

- Adds optional `xdp_ring_config_enabled` support for validator roles.
- Persists requested NIC RX/TX ring sizes through a systemd oneshot unit ordered before the validator service.
- Refuses to apply ring-size changes while the validator service is active, so runtime changes require a maintenance window.
- Adds `xdp_ring_interface`, `xdp_ring_rx`, and `xdp_ring_tx` role arguments with defaults.
- Adds optional expected shred version rendering to validator startup scripts.
- Adds `expected_shred_version_auto_detect` to query the configured RPC URL and select the majority non-zero cluster shred version when needed.
- Requires `expected_shred_version` when XDP zero-copy is effectively enabled outside localnet.

## 🧪 Testing

- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Manual testing completed
- [ ] Existing functionality verified unchanged
- [x] Documentation updated (if applicable)

### Test Details

- Ran `git diff --check upstream/main..HEAD`.
- Ran `ansible-playbook playbooks/pb_setup_validator_agave.yml --syntax-check -e target_host=localhost`.
- Ran `ansible-playbook playbooks/pb_setup_validator_jito_v2.yml --syntax-check -e target_host=localhost`.

## 📚 Documentation

- [x] Updated relevant documentation
- [ ] Added/updated comments for complex logic
- [ ] README updated (if applicable)
- [ ] No documentation changes needed

## 🔗 Related Issues

N/A

## 📝 Review Notes

Please focus on the safety behavior around applying NIC ring changes: the new task installs the persistent systemd unit, but refuses live ring changes while the validator service is active.

The expected shred version check is intended to make XDP zero-copy startup explicit on testnet/mainnet, while still allowing auto-detection when requested.

---

## For Reviewers

**Estimated review time:** ⏱️ 20 minutes

**Focus areas:**
- [x] Logic correctness
- [x] Security implications
- [x] Performance impact
- [ ] Documentation completeness
