### PR TITLE
[XDP Readiness Pack 1/3] Tune NIC ring buffer sizing

### DIFF
--- a/ansible-tests/scripts/test-ethtool-ring-buffers.sh
+++ b/ansible-tests/scripts/test-ethtool-ring-buffers.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RING_SCRIPT="${REPO_ROOT}/ansible/roles/server_initial_setup/files/set-ethtool-ring-buffers.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+SYS_CLASS_NET="${TMP_DIR}/sys/class/net"
+FAKE_BIN="${TMP_DIR}/bin"
+LOG_FILE="${TMP_DIR}/ethtool.log"
+OUT_FILE="${TMP_DIR}/ring-test.out"
+ERR_FILE="${TMP_DIR}/ring-test.err"
+mkdir -p "${SYS_CLASS_NET}/eno1/device" "${FAKE_BIN}"
+
+cat > "${FAKE_BIN}/ethtool" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+LOG_FILE="${FAKE_ETHTOOL_LOG}"
+MODE="${FAKE_RING_MODE}"
+
+if [[ "${1:-}" == "-g" ]]; then
+  case "${MODE}" in
+    max511)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		511
+TX:		511
+Current hardware settings:
+RX:		128
+TX:		128
+RINGS
+      ;;
+    max511_current511)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		511
+TX:		511
+Current hardware settings:
+RX:		511
+TX:		511
+RINGS
+      ;;
+    max512)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		512
+TX:		512
+Current hardware settings:
+RX:		128
+TX:		128
+RINGS
+      ;;
+    max1023)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		1023
+TX:		1023
+Current hardware settings:
+RX:		128
+TX:		128
+RINGS
+      ;;
+    max1023_current900)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		1023
+TX:		1023
+Current hardware settings:
+RX:		900
+TX:		900
+RINGS
+      ;;
+    max1)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		1
+TX:		1
+Current hardware settings:
+RX:		0
+TX:		0
+RINGS
+      ;;
+    nonnumeric)
+      cat <<'RINGS'
+Ring parameters for eno1:
+Pre-set maximums:
+RX:		n/a
+TX:		n/a
+Current hardware settings:
+RX:		n/a
+TX:		n/a
+RINGS
+      ;;
+    unsupported)
+      exit 1
+      ;;
+    *)
+      echo "unknown FAKE_RING_MODE=${MODE}" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "-G" ]]; then
+  echo "$*" >> "${LOG_FILE}"
+  if [[ "${FAKE_REJECT_512:-false}" == "true" && "${4:-}" == "512" ]]; then
+    exit 1
+  fi
+  if [[ "${FAKE_REJECT_256:-false}" == "true" && "${4:-}" == "256" ]]; then
+    exit 1
+  fi
+  if [[ "${FAKE_REJECT_1:-false}" == "true" && "${4:-}" == "1" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 2
+EOF
+chmod +x "${FAKE_BIN}/ethtool"
+
+run_case() {
+  local mode="$1"
+  local reject_512="$2"
+  local reject_256="${3:-false}"
+  local reject_1="${4:-false}"
+  : > "${LOG_FILE}"
+  : > "${OUT_FILE}"
+  : > "${ERR_FILE}"
+  FAKE_RING_MODE="${mode}" \
+    FAKE_REJECT_512="${reject_512}" \
+    FAKE_REJECT_256="${reject_256}" \
+    FAKE_REJECT_1="${reject_1}" \
+    FAKE_ETHTOOL_LOG="${LOG_FILE}" \
+    SYS_CLASS_NET="${SYS_CLASS_NET}" \
+    ETHTOOL_BIN="${FAKE_BIN}/ethtool" \
+    "${RING_SCRIPT}" >"${OUT_FILE}" 2>"${ERR_FILE}"
+}
+
+assert_log_contains() {
+  local expected="$1"
+  if ! grep -Fq -- "${expected}" "${LOG_FILE}"; then
+    echo "Expected ethtool log to contain: ${expected}" >&2
+    echo "Actual log:" >&2
+    cat "${LOG_FILE}" >&2
+    exit 1
+  fi
+}
+
+assert_log_not_contains() {
+  local unexpected="$1"
+  if grep -Fq -- "${unexpected}" "${LOG_FILE}"; then
+    echo "Expected ethtool log not to contain: ${unexpected}" >&2
+    echo "Actual log:" >&2
+    cat "${LOG_FILE}" >&2
+    exit 1
+  fi
+}
+
+assert_log_empty() {
+  if [[ -s "${LOG_FILE}" ]]; then
+    echo "Expected empty ethtool log, got:" >&2
+    cat "${LOG_FILE}" >&2
+    exit 1
+  fi
+}
+
+assert_err_contains() {
+  local expected="$1"
+  if ! grep -Fq -- "${expected}" "${ERR_FILE}"; then
+    echo "Expected stderr to contain: ${expected}" >&2
+    echo "Actual stderr:" >&2
+    cat "${ERR_FILE}" >&2
+    exit 1
+  fi
+}
+
+run_case_expect_success() {
+  local mode="$1"
+  local reject_512="$2"
+  local reject_256="${3:-false}"
+  local reject_1="${4:-false}"
+  if ! run_case "${mode}" "${reject_512}" "${reject_256}" "${reject_1}"; then
+    echo "Expected ring script to exit successfully for mode=${mode}" >&2
+    cat "${ERR_FILE}" >&2
+    exit 1
+  fi
+}
+
+run_case_expect_success max511 true
+assert_log_contains "-G eno1 rx 512"
+assert_log_contains "-G eno1 rx 256"
+assert_log_contains "-G eno1 tx 512"
+assert_log_contains "-G eno1 tx 256"
+
+run_case_expect_success max511 true true
+assert_log_contains "-G eno1 rx 512"
+assert_log_contains "-G eno1 rx 256"
+assert_log_contains "-G eno1 tx 512"
+assert_log_contains "-G eno1 tx 256"
+assert_err_contains "failed to set eno1 rx ring to target=512 or fallback=256"
+assert_err_contains "failed to set eno1 tx ring to target=512 or fallback=256"
+
+run_case_expect_success max511_current511 true
+assert_log_contains "-G eno1 rx 512"
+assert_log_not_contains "-G eno1 rx 256"
+assert_log_contains "-G eno1 tx 512"
+assert_log_not_contains "-G eno1 tx 256"
+
+run_case_expect_success max512 false
+assert_log_contains "-G eno1 rx 512"
+assert_log_contains "-G eno1 tx 512"
+
+run_case_expect_success max512 true
+assert_log_contains "-G eno1 rx 512"
+assert_log_contains "-G eno1 rx 256"
+assert_log_contains "-G eno1 tx 512"
+assert_log_contains "-G eno1 tx 256"
+
+run_case_expect_success max1023 false
+assert_log_contains "-G eno1 rx 512"
+assert_log_contains "-G eno1 tx 512"
+assert_log_not_contains "-G eno1 rx 1024"
+assert_log_not_contains "-G eno1 tx 1024"
+
+run_case_expect_success max1023_current900 false
+assert_log_empty
+
+run_case_expect_success max1 false false true
+assert_log_contains "-G eno1 rx 1"
+assert_log_contains "-G eno1 tx 1"
+assert_err_contains "no lower power-of-two fallback is available"
+
+run_case_expect_success nonnumeric false
+assert_log_empty
+
+run_case_expect_success unsupported false
+assert_log_empty
+
+echo "set-ethtool-ring-buffers tests passed"

--- a/ansible/roles/server_initial_setup/README.md
+++ b/ansible/roles/server_initial_setup/README.md
@@ -83,6 +83,16 @@ This role automates the initial configuration and hardening of a Solana validato
 
 For SSH, the role standardizes on `ssh.service` and disables `ssh.socket` if present, so port changes are controlled only through `/etc/ssh/sshd_config`. On Ubuntu-style socket-activated hosts, it also removes the socket-activation generator/drop-in state before starting `ssh.service`.
 
+## NIC Ring Buffer Tuning
+
+NIC ring buffers are configured by `ethtool-ring-buffers.service`. The helper
+targets power-of-two RX/TX ring sizes: it uses the maximum when already a power
+of two, tries `512` for the known `511` maximum quirk, and rounds other
+non-power-of-two maxima down. The helper only applies increases. If the NIC
+rejects the first attempt, it falls back to half the attempted power-of-two
+target only when that would increase the current ring size and a lower
+power-of-two fallback exists.
+
 ## Running the Playbook
 
 1. **Prepare the authorized IPs CSV:**

--- a/ansible/roles/server_initial_setup/files/set-ethtool-ring-buffers.sh
+++ b/ansible/roles/server_initial_setup/files/set-ethtool-ring-buffers.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+SYS_CLASS_NET="${SYS_CLASS_NET:-/sys/class/net}"
+ETHTOOL_BIN="${ETHTOOL_BIN:-ethtool}"
+
 is_physical_nic() {
   local nic_name="$1"
 
@@ -11,7 +14,7 @@ is_physical_nic() {
       ;;
   esac
 
-  [[ -d "/sys/class/net/${nic_name}/device" ]]
+  [[ -d "${SYS_CLASS_NET}/${nic_name}/device" ]]
 }
 
 ring_value() {
@@ -36,14 +39,108 @@ is_uint() {
   [[ "${1:-}" =~ ^[0-9]+$ ]]
 }
 
-for nic_path in /sys/class/net/*; do
+is_power_of_two() {
+  local value="$1"
+  is_uint "${value}" && ((value > 0)) && (((value & (value - 1)) == 0))
+}
+
+largest_power_of_two_at_or_below() {
+  local value="$1"
+  local power=1
+
+  if ! is_uint "${value}" || ((value < 1)); then
+    echo ""
+    return
+  fi
+
+  while ((power * 2 <= value)); do
+    power=$((power * 2))
+  done
+
+  echo "${power}"
+}
+
+preferred_power_of_two_ring() {
+  local max_value="$1"
+
+  if ! is_uint "${max_value}" || ((max_value < 1)); then
+    echo ""
+    return
+  fi
+
+  if is_power_of_two "${max_value}"; then
+    echo "${max_value}"
+    return
+  fi
+
+  # Some NICs report 511 while accepting 512; other non-power-of-two maxima round down.
+  if ((max_value == 511)); then
+    echo 512
+    return
+  fi
+
+  largest_power_of_two_at_or_below "${max_value}"
+}
+
+apply_ring_value() {
+  local nic_name="$1"
+  local direction="$2"
+  local current_value="$3"
+  local max_value="$4"
+  local desired_value fallback_value
+
+  if ! is_uint "${max_value}" || ! is_uint "${current_value}"; then
+    echo "Skipping ${nic_name} ${direction}: nonnumeric current/max ring values (current=${current_value:-unknown}, max=${max_value:-unknown})"
+    return 0
+  fi
+
+  desired_value="$(preferred_power_of_two_ring "${max_value}")"
+  if [[ -z "${desired_value}" ]]; then
+    echo "Skipping ${nic_name} ${direction}: unable to derive power-of-two target from max=${max_value}"
+    return 0
+  fi
+
+  if ((current_value >= desired_value)); then
+    echo "No ring buffer increase needed for ${nic_name} ${direction}: current=${current_value}, max=${max_value}, target=${desired_value}"
+    return 0
+  fi
+
+  echo "Setting ${nic_name} ${direction} ring: current=${current_value}, max=${max_value}, target=${desired_value}"
+  if "${ETHTOOL_BIN}" -G "${nic_name}" "${direction}" "${desired_value}"; then
+    echo "Set ${nic_name} ${direction} ring to ${desired_value}"
+    return 0
+  fi
+
+  fallback_value=$((desired_value / 2))
+  if ((fallback_value < 1)); then
+    echo "Warning: failed to set ${nic_name} ${direction} ring to ${desired_value}; no lower power-of-two fallback is available" >&2
+    return 0
+  fi
+
+  if ((current_value >= fallback_value)); then
+    echo "Keeping ${nic_name} ${direction} ring at current=${current_value} after target=${desired_value} was rejected; fallback=${fallback_value} would not increase the ring"
+    return 0
+  fi
+
+  echo "Retrying ${nic_name} ${direction} ring with fallback=${fallback_value} after target=${desired_value} was rejected"
+  if "${ETHTOOL_BIN}" -G "${nic_name}" "${direction}" "${fallback_value}"; then
+    echo "Set ${nic_name} ${direction} ring to fallback ${fallback_value}"
+  else
+    echo "Warning: failed to set ${nic_name} ${direction} ring to target=${desired_value} or fallback=${fallback_value}" >&2
+  fi
+
+  return 0
+}
+
+shopt -s nullglob
+for nic_path in "${SYS_CLASS_NET}"/*; do
   nic_name="$(basename "${nic_path}")"
 
   if ! is_physical_nic "${nic_name}"; then
     continue
   fi
 
-  ring_info="$(ethtool -g "${nic_name}" 2>/dev/null || true)"
+  ring_info="$("${ETHTOOL_BIN}" -g "${nic_name}" 2>/dev/null || true)"
   if [[ -z "${ring_info}" ]]; then
     echo "Skipping ${nic_name}: ring buffer information unavailable"
     continue
@@ -54,23 +151,6 @@ for nic_path in /sys/class/net/*; do
   tx_max="$(ring_value "Pre-set maximums:" "TX" <<< "${ring_info}")"
   tx_current="$(ring_value "Current hardware settings:" "TX" <<< "${ring_info}")"
 
-  # Empty or nonnumeric ring values are expected on some drivers and are ignored.
-  set_args=()
-  if is_uint "${rx_max}" && is_uint "${rx_current}" && ((rx_current < rx_max)); then
-    set_args+=(rx "${rx_max}")
-  fi
-
-  if is_uint "${tx_max}" && is_uint "${tx_current}" && ((tx_current < tx_max)); then
-    set_args+=(tx "${tx_max}")
-  fi
-
-  if [[ ${#set_args[@]} -eq 0 ]]; then
-    echo "No ring buffer changes needed for ${nic_name}"
-    continue
-  fi
-
-  echo "Setting ${nic_name} ring buffers: ${set_args[*]}"
-  if ! ethtool -G "${nic_name}" "${set_args[@]}"; then
-    echo "Warning: failed to set ring buffers for ${nic_name}" >&2
-  fi
+  apply_ring_value "${nic_name}" rx "${rx_current}" "${rx_max}"
+  apply_ring_value "${nic_name}" tx "${tx_current}" "${tx_max}"
 done


### PR DESCRIPTION
# [XDP Readiness Pack 1/3] Tune NIC ring buffer sizing

## 📝 Summary

Updates the server initial setup ring-buffer helper to choose power-of-two RX/TX ring sizes with a lower fallback when drivers reject the first target. Adds a focused shell test harness for the ring-buffer behavior.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🚀 Performance improvement
- [ ] ♻️ Code refactoring (no functional changes)

## 🔍 Scope & Complexity

**Please keep PRs focused and small for faster reviews.**

- [x] This PR changes **fewer than 400 lines** of code (excluding generated files)
- [x] This PR addresses **only one logical change** or feature
- [x] This PR can be **reviewed in under 30 minutes**
- [x] This PR does **not mix multiple types of changes** (e.g., refactoring + new features)

If any of the above are unchecked, consider breaking this PR into smaller, focused changes.

## 📋 Changes Made

Detailed list of changes:

- Updates `set-ethtool-ring-buffers.sh` to target power-of-two ring sizes.
- Retries with half the attempted target when a NIC rejects the first power-of-two value.
- Fixes local scoping for the `next_power` helper variable.
- Adds a shell test harness covering `511 -> 512 -> 256`, rejected `512 -> 256`, nonnumeric values, and unsupported ring queries.
- Documents the ring-buffer sizing behavior in the server initial setup README.

## 🧪 Testing

- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Manual testing completed
- [x] Existing functionality verified unchanged
- [x] Documentation updated (if applicable)

### Test Details

Validated with:

- `bash -n ansible/roles/server_initial_setup/files/set-ethtool-ring-buffers.sh`
- `bash -n ansible-tests/scripts/test-ethtool-ring-buffers.sh`
- `ansible-tests/scripts/test-ethtool-ring-buffers.sh`

## 📚 Documentation

- [x] Updated relevant documentation
- [ ] Added/updated comments for complex logic
- [x] README updated (if applicable)
- [ ] No documentation changes needed

## 🔗 Related Issues

N/A

## 📝 Review Notes

This is **Pack 1/3**. Suggested review/merge order:

1. Pack 1/3: ring-buffer tuning
2. Pack 2/3: XDP acquisition probe script
3. Pack 3/3: XDP readiness wiring

This PR is independent, but it is named as part of the XDP readiness pack so reviewers can track the series.

---

## For Reviewers

**Estimated review time:** ⏱️ 15 minutes

**Focus areas:**
- [x] Logic correctness
- [ ] Security implications
- [ ] Performance impact
- [x] Documentation completeness
